### PR TITLE
Fail Compilation with a Diagnostic Error When No CFPropertyList Stream Read/Write APIs Are Defined

### DIFF
--- a/src/CFUtilities.cpp
+++ b/src/CFUtilities.cpp
@@ -721,6 +721,8 @@ CFUPropertyListReadFromURL(CFURLRef            inURL,
                                                &theFormat,
                                                outError);
     __Require_Action(*outPlist != NULL, done, status = false);
+#else // !HAVE_CFPROPERTYLISTCREATEWITHSTREAM || !HAVE_CFPROPERTYLISTCREATEFROMSTREAM
+#error "One of 'CFPropertyListCreateWithStream' or 'CFPropertyListCreateFromStream' must be available."
 #endif // HAVE_CFPROPERTYLISTCREATEWITHSTREAM
 
     // At this point, all operations were successful. Set the return
@@ -818,6 +820,8 @@ CFUPropertyListWriteToURL(CFURLRef             inURL,
                                            inFormat,
                                            outError);
     __Require_Action(theIndex != 0, done, status = false);
+#else // !HAVE_CFPROPERTYLISTWRITE || !HAVE_CFPROPERTYLISTWRITETOSTREAM
+#error "One of 'CFPropertyListWrite' or 'CFPropertyListWriteToStream' must be available."
 #endif // HAVE_CFPROPERTYLISTWRITE
 
     // At this point, all operations were successful. Set the return


### PR DESCRIPTION
This addresses #7 by failing compilation with a diagnostic error when none of:
    
 - HAVE_CFPROPERTYLISTCREATEWITHSTREAM or HAVE_CFPROPERTYLISTCREATEFROMSTREAM

and:

 - HAVE_CFPROPERTYLISTWRITE or HAVE_CFPROPERTYLISTWRITETOSTREAM

are defined.