### PR TITLE
Remove OpenCFLite 476 Version Number in Comment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@
 #
 #    Description:
 #      This file is the GitHub Actions hosted, distributed continuous
-#      integration configuration file for the Nuovations Log
+#      integration configuration file for the Nuovations CoreFoundation
 #      Utilities library.
 #
 
@@ -47,6 +47,7 @@ jobs:
     env:
       CC: ${{matrix.compiler['c']}}
       CXX: ${{matrix.compiler['cxx']}}
+
     steps:
 
     - name: Install Common Host Package Dependencies
@@ -68,6 +69,35 @@ jobs:
         curl https://data.iana.org/time-zones/releases/tzcode2021a.tar.gz -o tzcode2021a.tar.gz || wget https://data.iana.org/time-zones/releases/tzcode2021a.tar.gz
         mkdir tzcode2021a
         tar --directory tzcode2021a -zxf tzcode2021a.tar.gz
+
+    - name: Checkout libkqueue OpenCFLite v635 Dependency
+      if: ${{matrix.opencflite['ref']}} == 'opencflite-635'
+      uses: actions/checkout@v2
+      with:
+        repository: mheily/libkqueue
+        ref: master
+        path: libkqueue
+
+    - name: Configure libkqueue OpenCFLite v635 Dependency
+      if: ${{matrix.opencflite['ref']}} == 'opencflite-635'
+      run: |
+        cd "${GITHUB_WORKSPACE}/libkqueue"
+        cmake -S. -B. -G "Unix Makefiles" \
+          -DCMAKE_INSTALL_PREFIX="/usr" \
+          -DCMAKE_INSTALL_LIBDIR="lib"
+
+    - name: Build libkqueue OpenCFLite v635 Dependency
+      if: ${{matrix.opencflite['ref']}} == 'opencflite-635'
+      run: |
+        cd "${GITHUB_WORKSPACE}/libkqueue"
+        make -j
+
+    - name: Install libkqueue OpenCFLite v635 Dependency
+      if: ${{matrix.opencflite['ref']}} == 'opencflite-635'
+      run: |
+        cd "${GITHUB_WORKSPACE}/libkqueue"
+        sudo make install
+        sudo ldconfig
 
     - name: Checkout OpenCFLite Dependency
       uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
         tar --directory tzcode2021a -zxf tzcode2021a.tar.gz
 
     - name: Checkout libkqueue OpenCFLite v635 Dependency
-      if: ${{matrix.opencflite['ref']}} == 'opencflite-635'
+      if: matrix.opencflite['ref'] == 'opencflite-635'
       uses: actions/checkout@v2
       with:
         repository: mheily/libkqueue
@@ -79,7 +79,7 @@ jobs:
         path: libkqueue
 
     - name: Configure libkqueue OpenCFLite v635 Dependency
-      if: ${{matrix.opencflite['ref']}} == 'opencflite-635'
+      if: matrix.opencflite['ref'] == 'opencflite-635'
       run: |
         cd "${GITHUB_WORKSPACE}/libkqueue"
         cmake -S. -B. -G "Unix Makefiles" \
@@ -87,13 +87,13 @@ jobs:
           -DCMAKE_INSTALL_LIBDIR="lib"
 
     - name: Build libkqueue OpenCFLite v635 Dependency
-      if: ${{matrix.opencflite['ref']}} == 'opencflite-635'
+      if: matrix.opencflite['ref'] == 'opencflite-635'
       run: |
         cd "${GITHUB_WORKSPACE}/libkqueue"
         make -j
 
     - name: Install libkqueue OpenCFLite v635 Dependency
-      if: ${{matrix.opencflite['ref']}} == 'opencflite-635'
+      if: matrix.opencflite['ref'] == 'opencflite-635'
       run: |
         cd "${GITHUB_WORKSPACE}/libkqueue"
         sudo make install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,7 +93,7 @@ jobs:
         make -j
 
     # Make sure that 'ldconfig' is run such that run time execution
-    # picks up libCoreFoundation.so.476 in /usr/local.
+    # picks up libCoreFoundation.so in /usr/local.
 
     - name: Install OpenCFLite Dependency
       run: |


### PR DESCRIPTION
Remove 476 version number in comment since the CI matrix does both versions 476 and 635 of OpenCFLite.