### PR TITLE
Add 'CFUDictionaryDifference' C/C++ Bindings

### DIFF
--- a/include/CFUtilities/CFUtilities.h
+++ b/include/CFUtilities/CFUtilities.h
@@ -1,5 +1,5 @@
 /*
- *    Copyright (c) 2008-2021 Nuovation System Designs, LLC
+ *    Copyright (c) 2008-2023 Nuovation System Designs, LLC
  *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -58,6 +58,11 @@ extern void            CFUDictionaryMerge(CFMutableDictionaryRef inDestination,
 extern Boolean         CFUDictionarySetCString(CFMutableDictionaryRef inDestination,
                                                const void *           inKey,
                                                const char *           inString);
+extern Boolean         CFUDictionaryDifference(CFDictionaryRef          inProposed,
+                                               CFMutableDictionaryRef * inOutBase,
+                                               CFMutableDictionaryRef   outAdded,
+                                               CFMutableDictionaryRef   outCommon,
+                                               CFMutableDictionaryRef   outRemoved);
 
 // CFNumber Operations
 

--- a/include/CFUtilities/CFUtilities.hpp
+++ b/include/CFUtilities/CFUtilities.hpp
@@ -1,5 +1,5 @@
 /*
- *    Copyright (c) 2008-2021 Nuovation System Designs, LLC
+ *    Copyright (c) 2008-2023 Nuovation System Designs, LLC
  *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -311,6 +311,11 @@ extern Boolean CFUDictionaryGetBoolean(CFDictionaryRef inDictionary,
 extern Boolean CFUDictionarySetBoolean(CFMutableDictionaryRef inDictionary,
                                        const void *           inKey,
                                        Boolean                inValue);
+extern Boolean CFUDictionaryDifference(CFDictionaryRef          inProposed,
+                                       CFMutableDictionaryRef & inOutBase,
+                                       CFMutableDictionaryRef   outAdded,
+                                       CFMutableDictionaryRef   outCommon,
+                                       CFMutableDictionaryRef   outRemoved);
 
 extern Boolean CFUPropertyListReadFromFile(CFStringRef         inPath,
                                            CFOptionFlags       inMutability,

--- a/src/CFUtilities.cpp
+++ b/src/CFUtilities.cpp
@@ -40,7 +40,7 @@
 using namespace std;
 
 
-/* Type Definitions */
+// MARK: Type Definitions
 
 /*
  * NOTE: Regrettably, clang-format is disabled below since
@@ -84,7 +84,7 @@ struct CFUSetContext {
     // clang-format on
 };
 
-/* Global Variables */
+// MARK: Global Variables
 
 static const CFTreeContext kCFUTreeContextInitializer = { 0, 0, 0, 0, 0 };
 

--- a/src/CFUtilities.cpp
+++ b/src/CFUtilities.cpp
@@ -109,7 +109,7 @@ CFUIsTypeID(CFTypeRef inReference, CFTypeID inID)
 {
     bool status = false;
 
-    __Require_Quiet(inReference != NULL, done);
+    __Require_Quiet(inReference != nullptr, done);
 
     status = (CFGetTypeID(inReference) == inID);
 
@@ -125,12 +125,12 @@ done:
  *  object.
  *
  *  @note
- *    In contrast to the @a CFRelease interface, a NULL reference results
+ *    In contrast to the @a CFRelease interface, a null reference results
  *    in no action being taken.
  *
  *  @param[in,out]  inReference  A reference to the CoreFoundation
  *                               object to release. On success, if
- *                               @a inReference is non-NULL, the
+ *                               @a inReference is non-null, the
  *                               reference is released.
  *
  *  @ingroup base
@@ -139,7 +139,7 @@ done:
 void
 CFURelease(CFTypeRef inReference)
 {
-    if (inReference != NULL) {
+    if (inReference != nullptr) {
         CFRelease(inReference);
     }
 }
@@ -221,7 +221,7 @@ CFUDateGetPOSIXTime(CFDateRef inDate)
 {
     time_t tempTime = 0;
 
-    __Require(inDate != NULL, done);
+    __Require(inDate != nullptr, done);
 
     tempTime = CFUAbsoluteTimeGetPOSIXTime(CFDateGetAbsoluteTime(inDate));
 
@@ -238,7 +238,7 @@ done:
  *  @param[in]  inTime       The POSIX time to convert.
  *
  *  @returns
- *    A reference to a CoreFoundation date object if OK; otherwise, NULL.
+ *    A reference to a CoreFoundation date object if OK; otherwise, null.
  *
  *  @ingroup date-time
  *
@@ -258,7 +258,7 @@ CFUDateCreate(CFAllocatorRef inAllocator, time_t inTime)
  *
  *  @returns
  *    A reference to an array containing the keys on success;
- *    otherwise, NULL on error.
+ *    otherwise, null on error.
  *
  *  @ingroup dictionary
  *
@@ -268,15 +268,15 @@ CFUDictionaryCopyKeys(CFDictionaryRef inDictionary)
 {
     CFIndex              numKeys;
     vector<const void *> theKeys;
-    CFArrayRef           arrayRef = NULL;
+    CFArrayRef           arrayRef = nullptr;
 
-    __Require(inDictionary != NULL, done);
+    __Require(inDictionary != nullptr, done);
 
     numKeys = CFDictionaryGetCount(inDictionary);
 
     theKeys.reserve(static_cast<size_t>(numKeys));
 
-    CFDictionaryGetKeysAndValues(inDictionary, &theKeys[0], NULL);
+    CFDictionaryGetKeysAndValues(inDictionary, &theKeys[0], nullptr);
 
     arrayRef = CFArrayCreate(kCFAllocatorDefault,
                              &theKeys[0],
@@ -308,11 +308,11 @@ CFUDictionaryMergeApplier(const void * inKey,
                           const void * inValue,
                           void *       inContext)
 {
-    CFUDictionaryMergeContext * theContext = NULL;
+    CFUDictionaryMergeContext * theContext = nullptr;
     bool                        hasKey;
 
-    __Require(inKey != NULL, done);
-    __Require(inContext != NULL, done);
+    __Require(inKey != nullptr, done);
+    __Require(inContext != nullptr, done);
 
     theContext = static_cast<CFUDictionaryMergeContext *>(inContext);
 
@@ -372,8 +372,8 @@ CFUDictionaryMerge(CFMutableDictionaryRef inDestination,
 {
     CFUDictionaryMergeContext theContext = { inDestination, inReplace };
 
-    __Require(inDestination != NULL, done);
-    __Require(inSource != NULL, done);
+    __Require(inDestination != nullptr, done);
+    __Require(inSource != nullptr, done);
 
     CFDictionaryApplyFunction(inSource, CFUDictionaryMergeApplier, &theContext);
 
@@ -453,12 +453,12 @@ CFUDictionaryGetBoolean(CFDictionaryRef inDictionary,
                         Boolean &       outValue)
 {
     bool         status      = false;
-    CFBooleanRef tempBoolean = NULL;
+    CFBooleanRef tempBoolean = nullptr;
 
     // Sanity check the input parameters.
 
-    __Require(inDictionary != NULL, done);
-    __Require(inKey != NULL, done);
+    __Require(inDictionary != nullptr, done);
+    __Require(inKey != nullptr, done);
 
     // Attempt to get the value from the dictionary.
 
@@ -468,7 +468,7 @@ CFUDictionaryGetBoolean(CFDictionaryRef inDictionary,
     // The key being absent is a quiet failure; whereas, the value not
     // being of type Boolean is.
 
-    __Require_Quiet(tempBoolean != NULL, done);
+    __Require_Quiet(tempBoolean != nullptr, done);
     __Require(CFUIsTypeID(tempBoolean, CFBooleanGetTypeID()), done);
 
     outValue = CFBooleanGetValue(tempBoolean);
@@ -511,8 +511,8 @@ CFUDictionarySetBoolean(CFMutableDictionaryRef inDictionary,
 {
     bool status = false;
 
-    __Require(inDictionary != NULL, done);
-    __Require(inKey != NULL, done);
+    __Require(inDictionary != nullptr, done);
+    __Require(inKey != nullptr, done);
 
     CFDictionarySetValue(inDictionary,
                          inKey,
@@ -526,23 +526,23 @@ done:
 
 /**
  *  @brief
- *    Add a NULL-termited C string to a dictionary.
+ *    Add a null-termited C string to a dictionary.
 
- *  This routine sets the specified NULL-terminated C string value, as
+ *  This routine sets the specified null-terminated C string value, as
  *  a CFString, in the provided dictionary associated with the
  *  specified key.
  *
  *  @param[in,out]  inDictionary  A reference to the CoreFoundation
  *                                dictionary to set the
- *                                NULL-terminated C string in. On
+ *                                null-terminated C string in. On
  *                                success, the dictionary is modified
  *                                with a reference to the CFString
  *                                value equivalent to the
- *                                NULL-terminated C string set.
+ *                                null-terminated C string set.
  *  @param[in]      inKey         A pointer to the key with which to
- *                                associate the NULL-terminated C
+ *                                associate the null-terminated C
  *                                string in the dictionary.
- *  @param[in]      inString      The NULL-terminated C string value to set.
+ *  @param[in]      inString      The null-terminated C string value to set.
  *
  *  @returns
  *    True if the value was successfully set; otherwise, false.
@@ -556,16 +556,16 @@ CFUDictionarySetCString(CFMutableDictionaryRef inDictionary,
                         const char *           inString)
 {
     bool        status     = false;
-    CFStringRef tempString = NULL;
+    CFStringRef tempString = nullptr;
 
-    __Require(inDictionary != NULL, done);
-    __Require(inKey != NULL, done);
-    __Require(inString != NULL, done);
+    __Require(inDictionary != nullptr, done);
+    __Require(inKey != nullptr, done);
+    __Require(inString != nullptr, done);
 
     tempString = CFStringCreateWithCString(kCFAllocatorDefault,
                                            inString,
                                            CFStringGetSystemEncoding());
-    __Require(tempString != NULL, done);
+    __Require(tempString != nullptr, done);
 
     CFDictionarySetValue(inDictionary, inKey, tempString);
 
@@ -664,18 +664,18 @@ CFUPropertyListReadFromURL(CFURLRef            inURL,
                            CFStringRef *       outError)
 {
     bool                 status    = false;
-    CFReadStreamRef      theStream = NULL;
+    CFReadStreamRef      theStream = nullptr;
     CFStreamStatus       streamStatus;
     CFPropertyListFormat theFormat;
 
-    __Require(inURL != NULL, done);
-    __Require(outPlist != NULL, done);
+    __Require(inURL != nullptr, done);
+    __Require(outPlist != nullptr, done);
 
     // Attempt to create a CoreFoundation read file stream from the
     // resulting URL.
 
     theStream = CFReadStreamCreateWithFile(kCFAllocatorDefault, inURL);
-    __Require(theStream != NULL, done);
+    __Require(theStream != nullptr, done);
 
     // Attempt to open the stream.
 
@@ -694,7 +694,7 @@ CFUPropertyListReadFromURL(CFURLRef            inURL,
 
 #if HAVE_CFPROPERTYLISTCREATEWITHSTREAM
     {
-        CFErrorRef theError = NULL;
+        CFErrorRef theError = nullptr;
 
         *outPlist = CFPropertyListCreateWithStream(kCFAllocatorDefault,
                                                    theStream,
@@ -703,15 +703,15 @@ CFUPropertyListReadFromURL(CFURLRef            inURL,
                                                    &theFormat,
                                                    &theError);
 
-        if (theError != NULL) {
-            if (outError != NULL) {
+        if (theError != nullptr) {
+            if (outError != nullptr) {
                 *outError = CFErrorCopyDescription(theError);
             }
 
             CFRelease(theError);
         }
 
-        __Require_Action(*outPlist != NULL, done, status = false);
+        __Require_Action(*outPlist != nullptr, done, status = false);
     }
 #elif HAVE_CFPROPERTYLISTCREATEFROMSTREAM
     *outPlist = CFPropertyListCreateFromStream(kCFAllocatorDefault,
@@ -720,7 +720,7 @@ CFUPropertyListReadFromURL(CFURLRef            inURL,
                                                inMutability,
                                                &theFormat,
                                                outError);
-    __Require_Action(*outPlist != NULL, done, status = false);
+    __Require_Action(*outPlist != nullptr, done, status = false);
 #else // !HAVE_CFPROPERTYLISTCREATEWITHSTREAM || !HAVE_CFPROPERTYLISTCREATEFROMSTREAM
 #error "One of 'CFPropertyListCreateWithStream' or 'CFPropertyListCreateFromStream' must be available."
 #endif // HAVE_CFPROPERTYLISTCREATEWITHSTREAM
@@ -731,7 +731,7 @@ CFUPropertyListReadFromURL(CFURLRef            inURL,
     status = true;
 
 done:
-    if (theStream != NULL) {
+    if (theStream != nullptr) {
         CFReadStreamClose(theStream);
     }
 
@@ -771,18 +771,18 @@ CFUPropertyListWriteToURL(CFURLRef             inURL,
                           CFStringRef *        outError)
 {
     bool             status    = false;
-    CFWriteStreamRef theStream = NULL;
+    CFWriteStreamRef theStream = nullptr;
     CFStreamStatus   streamStatus;
     CFIndex          theIndex;
 
-    __Require(inURL != NULL, done);
-    __Require(inPlist != NULL, done);
+    __Require(inURL != nullptr, done);
+    __Require(inPlist != nullptr, done);
 
     // Attempt to create a CoreFoundation write file stream from the
     // specified URL.
 
     theStream = CFWriteStreamCreateWithFile(kCFAllocatorDefault, inURL);
-    __Require(theStream != NULL, done);
+    __Require(theStream != nullptr, done);
 
     // Attempt to open the stream.
 
@@ -796,7 +796,7 @@ CFUPropertyListWriteToURL(CFURLRef             inURL,
 
 #if HAVE_CFPROPERTYLISTWRITE
     {
-        CFErrorRef theError = NULL;
+        CFErrorRef theError = nullptr;
 
         theIndex = CFPropertyListWrite(inPlist,
                                        theStream,
@@ -804,8 +804,8 @@ CFUPropertyListWriteToURL(CFURLRef             inURL,
                                        0,
                                        &theError);
 
-        if (theError != NULL) {
-            if (outError != NULL) {
+        if (theError != nullptr) {
+            if (outError != nullptr) {
                 *outError = CFErrorCopyDescription(theError);
             }
 
@@ -830,7 +830,7 @@ CFUPropertyListWriteToURL(CFURLRef             inURL,
     status = true;
 
 done:
-    if (theStream != NULL) {
+    if (theStream != nullptr) {
         CFWriteStreamClose(theStream);
     }
 
@@ -879,10 +879,10 @@ CFUPropertyListReadFromFile(CFStringRef         inPath,
 {
     bool     kIsDirectory = true;
     bool     status       = false;
-    CFURLRef theURL       = NULL;
+    CFURLRef theURL       = nullptr;
 
-    __Require(inPath != NULL, done);
-    __Require(outPlist != NULL, done);
+    __Require(inPath != nullptr, done);
+    __Require(outPlist != nullptr, done);
 
     // Attempt to create a CoreFoundation URL for the specified file
     // path.
@@ -891,7 +891,7 @@ CFUPropertyListReadFromFile(CFStringRef         inPath,
                                            inPath,
                                            kCFURLPOSIXPathStyle,
                                            !kIsDirectory);
-    __Require(theURL != NULL, done);
+    __Require(theURL != nullptr, done);
 
     // Attempt to read the property list from the URL.
 
@@ -943,10 +943,10 @@ CFUPropertyListWriteToFile(CFStringRef          inPath,
 {
     bool     kIsDirectory = true;
     bool     status       = false;
-    CFURLRef theURL       = NULL;
+    CFURLRef theURL       = nullptr;
 
-    __Require(inPath != NULL, done);
-    __Require(inPlist != NULL, done);
+    __Require(inPath != nullptr, done);
+    __Require(inPlist != nullptr, done);
 
     // Attempt to create a CoreFoundation URL for the specified file
     // path.
@@ -955,7 +955,7 @@ CFUPropertyListWriteToFile(CFStringRef          inPath,
                                            inPath,
                                            kCFURLPOSIXPathStyle,
                                            !kIsDirectory);
-    __Require(theURL != NULL, done);
+    __Require(theURL != nullptr, done);
 
     // Attempt to write the property list to the URL.
 
@@ -1007,17 +1007,17 @@ CFUPropertyListReadFromFile(const char *        inPath,
                             CFStringRef *       outError)
 {
     bool        status  = false;
-    CFStringRef thePath = NULL;
+    CFStringRef thePath = nullptr;
 
-    __Require(inPath != NULL, done);
-    __Require(outPlist != NULL, done);
+    __Require(inPath != nullptr, done);
+    __Require(outPlist != nullptr, done);
 
     // Convert the provided path name to a CoreFoundation string.
 
     thePath = CFStringCreateWithCString(kCFAllocatorDefault,
                                         inPath,
                                         CFStringGetSystemEncoding());
-    __Require(thePath != NULL, done);
+    __Require(thePath != nullptr, done);
 
     // Attempt to read the property list from the file at the
     // specified path.
@@ -1071,21 +1071,21 @@ CFUPropertyListWriteToFile(const char *         inPath,
                            CFStringRef *        outError)
 {
     int          error;
-    CFStringRef  thePath     = NULL;
+    CFStringRef  thePath     = nullptr;
     const mode_t kReadAll    = (S_IRUSR | S_IRGRP | S_IROTH);
     const mode_t kWriteAll   = (S_IWUSR | S_IWGRP | S_IWOTH);
     const mode_t permissions = inWritable ? (kReadAll | kWriteAll) : kReadAll;
     bool         status      = false;
 
-    __Require(inPath != NULL, done);
-    __Require(inPlist != NULL, done);
+    __Require(inPath != nullptr, done);
+    __Require(inPlist != nullptr, done);
 
     // Convert the provided path name to a CoreFoundation string.
 
     thePath = CFStringCreateWithCString(kCFAllocatorDefault,
                                         inPath,
                                         CFStringGetSystemEncoding());
-    __Require(thePath != NULL, done);
+    __Require(thePath != nullptr, done);
 
     // Attempt to write the property list to the file at the specified
     // path.
@@ -1117,7 +1117,7 @@ done:
  *
  *  @returns
  *    True if the set is the empty set or the specified reference is
- *    NULL; otherwise, false.
+ *    null; otherwise, false.
  *
  *  @ingroup set
  *
@@ -1125,7 +1125,7 @@ done:
 bool
 CFUSetIsEmptySet(CFSetRef inSet)
 {
-    return ((inSet == NULL) ? true : (CFSetGetCount(inSet) == 0));
+    return ((inSet == nullptr) ? true : (CFSetGetCount(inSet) == 0));
 }
 
 /**
@@ -1179,7 +1179,7 @@ CFUSetIntersectionSet(CFMutableSetRef inDestinationSet, CFSetRef inSourceSet)
 {
     CFUSetContext theContext = { inDestinationSet, inSourceSet };
 
-    if (inDestinationSet != NULL && inSourceSet != NULL) {
+    if (inDestinationSet != nullptr && inSourceSet != nullptr) {
         CFSetApplyFunction(inDestinationSet,
                            CFUSetIntersectionApplier,
                            &theContext);
@@ -1236,7 +1236,7 @@ CFUSetUnionSet(CFMutableSetRef inDestinationSet, CFSetRef inSourceSet)
 {
     CFUSetContext theContext = { inDestinationSet, inSourceSet };
 
-    if (inDestinationSet != NULL && inSourceSet != NULL) {
+    if (inDestinationSet != nullptr && inSourceSet != nullptr) {
         CFSetApplyFunction(inSourceSet, CFUSetUnionApplier, &theContext);
     }
 
@@ -1258,7 +1258,7 @@ CFUSetUnionSet(CFMutableSetRef inDestinationSet, CFSetRef inSourceSet)
 void
 CFUTreeContextInit(CFTreeContext * inContext)
 {
-    if (inContext != NULL) {
+    if (inContext != nullptr) {
         *inContext = kCFUTreeContextInitializer;
     }
 }
@@ -1275,7 +1275,7 @@ CFUTreeContextInit(CFTreeContext * inContext)
  *                          by one.
  *
  *  @returns
- *    A reference to the newly-created tree if OK; otherwise, NULL on
+ *    A reference to the newly-created tree if OK; otherwise, null on
  *    error.
  *
  *  @ingroup tree
@@ -1284,7 +1284,7 @@ CFUTreeContextInit(CFTreeContext * inContext)
 CFTreeRef
 CFUTreeCreate(CFTypeRef inType)
 {
-    CFTreeRef     tempTree = NULL;
+    CFTreeRef     tempTree = nullptr;
     CFTreeContext theContext;
 
     CFUTreeContextInit(&theContext);
@@ -1295,7 +1295,7 @@ CFUTreeCreate(CFTypeRef inType)
     theContext.copyDescription = CFCopyDescription;
 
     tempTree = CFTreeCreate(kCFAllocatorDefault, &theContext);
-    __Require(tempTree != NULL, done);
+    __Require(tempTree != nullptr, done);
 
 done:
     return (tempTree);
@@ -1320,7 +1320,7 @@ CFUStringsMatch(CFStringRef aFirst, CFStringRef aSecond)
     CFComparisonResult comparison;
     bool               match = false;
 
-    if ((aFirst != NULL) && (aSecond != NULL)) {
+    if ((aFirst != nullptr) && (aSecond != nullptr)) {
         comparison = CFStringCompare(aFirst, aSecond, 0);
 
         match = (comparison == kCFCompareEqualTo);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,5 +1,5 @@
 #
-#    Copyright (c) 2021 Nuovation System Designs, LLC. All Rights Reserved.
+#    Copyright (c) 2021-2023 Nuovation System Designs, LLC. All Rights Reserved.
 #    Copyright 2016 Nest Labs Inc. All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
@@ -60,6 +60,7 @@ check_PROGRAMS                          = \
     TestCFUDateCreate                     \
     TestCFUDateGetPOSIXTime               \
     TestCFUDictionaryCopyKeys             \
+    TestCFUDictionaryDifference           \
     TestCFUDictionaryMerge                \
     TestCFUDictionaryGetBoolean           \
     TestCFUDictionarySetBoolean           \
@@ -117,6 +118,10 @@ TestCFUDateCreate_SOURCES               = TestDriver.cpp                      \
 TestCFUDictionaryCopyKeys_LDADD         = $(COMMON_LDADD)
 TestCFUDictionaryCopyKeys_SOURCES       = TestDriver.cpp                      \
                                           TestCFUDictionaryCopyKeys.cpp
+
+TestCFUDictionaryDifference_LDADD       = $(COMMON_LDADD)
+TestCFUDictionaryDifference_SOURCES     = TestDriver.cpp                      \
+                                          TestCFUDictionaryDifference.cpp
 
 TestCFUDictionaryMerge_LDADD            = $(COMMON_LDADD)
 TestCFUDictionaryMerge_SOURCES          = TestDriver.cpp                      \

--- a/tests/TestCFUDictionaryDifference.cpp
+++ b/tests/TestCFUDictionaryDifference.cpp
@@ -90,7 +90,7 @@ TestCFUDictionaryDifference :: TestNull(void)
     CFMutableDictionaryRef lBaseDictionaryRef     = nullptr;
     CFMutableDictionaryRef lAddedDictionaryRef    = nullptr;
     CFMutableDictionaryRef lCommonDictionaryRef   = nullptr;
-    CFMutableDictionaryRef lRemovedDictionaryRef  = nullptr;   
+    CFMutableDictionaryRef lRemovedDictionaryRef  = nullptr;
     Boolean                lStatus;
 
     // Allocate the added, common, and removed dictionaries
@@ -1461,7 +1461,7 @@ TestCFUDictionaryDifference :: TestDictionaryKeysAndValues(CFDictionaryRef inDic
                                                            const size_t &inExpectedCount)
 {
     CFIndex lDictionaryCount;
-    
+
     CPPUNIT_ASSERT(inDictionary != nullptr);
 
     lDictionaryCount = CFDictionaryGetCount(inDictionary);

--- a/tests/TestCFUDictionaryDifference.cpp
+++ b/tests/TestCFUDictionaryDifference.cpp
@@ -31,10 +31,54 @@ class TestCFUDictionaryDifference :
 {
     CPPUNIT_TEST_SUITE(TestCFUDictionaryDifference);
     CPPUNIT_TEST(TestNull);
+    CPPUNIT_TEST(TestEmptyProposed);
+    CPPUNIT_TEST(TestEmptyBase);
+    CPPUNIT_TEST(TestIdenticalBaseAndProposed);
+    CPPUNIT_TEST(TestDisjointBaseAndProposed);
+    CPPUNIT_TEST(TestBaseIsStrictSubsetOfProposed);
+    CPPUNIT_TEST(TestBaseIsStrictSupersetOfProposed);
+    CPPUNIT_TEST(TestBaseAndProposedDifferInCommonValuesAndHaveNoUniqueEntries);
+    CPPUNIT_TEST(TestBaseAndProposedDifferInCommonValuesAndHaveUniqueEntries);
+    CPPUNIT_TEST(TestBaseAndProposedHaveCommonValuesAndHaveUniqueEntries);
+    CPPUNIT_TEST(TestBaseAndProposedHaveCommonValuesAndHaveUniqueEntriesAddedResultsOnly);
+    CPPUNIT_TEST(TestBaseAndProposedHaveCommonValuesAndHaveUniqueEntriesCommonResultsOnly);
+    CPPUNIT_TEST(TestBaseAndProposedHaveCommonValuesAndHaveUniqueEntriesRemovedResultsOnly);
     CPPUNIT_TEST_SUITE_END();
 
 public:
     void TestNull(void);
+    void TestEmptyProposed(void);
+    void TestEmptyBase(void);
+    void TestIdenticalBaseAndProposed(void);
+    void TestDisjointBaseAndProposed(void);
+    void TestBaseIsStrictSubsetOfProposed(void);
+    void TestBaseIsStrictSupersetOfProposed(void);
+    void TestBaseAndProposedDifferInCommonValuesAndHaveNoUniqueEntries(void);
+    void TestBaseAndProposedDifferInCommonValuesAndHaveUniqueEntries(void);
+    void TestBaseAndProposedHaveCommonValuesAndHaveUniqueEntries(void);
+    void TestBaseAndProposedHaveCommonValuesAndHaveUniqueEntriesAddedResultsOnly(void);
+    void TestBaseAndProposedHaveCommonValuesAndHaveUniqueEntriesCommonResultsOnly(void);
+    void TestBaseAndProposedHaveCommonValuesAndHaveUniqueEntriesRemovedResultsOnly(void);
+
+private:
+    void TestSetup(CFMutableDictionaryRef &outAdded,
+                   CFMutableDictionaryRef &outCommon,
+                   CFMutableDictionaryRef &outRemoved);
+    void TestDictionaryCreateWithKeysAndValues(const void **inFirstKey,
+                                               const void **inFirstValue,
+                                               const size_t &inCount,
+                                               CFDictionaryRef &outDictionary);
+    void TestDictionaryCreateWithKeysAndValues(const void **inFirstKey,
+                                               const void **inFirstValue,
+                                               const size_t &inCount,
+                                               CFMutableDictionaryRef &outDictionary);
+    void TestDictionaryKeysAndValues(CFDictionaryRef inDictionary,
+                                     const void **inExpectedFirstKey,
+                                     const void **inExpectedFirstValue,
+                                     const size_t &inExpectedCount);
+    void TestTeardown(CFMutableDictionaryRef inAdded,
+                      CFMutableDictionaryRef inCommon,
+                      CFMutableDictionaryRef inRemoved);
 };
 
 CPPUNIT_TEST_SUITE_REGISTRATION(TestCFUDictionaryDifference);
@@ -51,23 +95,9 @@ TestCFUDictionaryDifference :: TestNull(void)
 
     // Allocate the added, common, and removed dictionaries
 
-    lAddedDictionaryRef = CFDictionaryCreateMutable(kCFAllocatorDefault,
-                                                    0,
-                                                    &kCFTypeDictionaryKeyCallBacks,
-                                                    &kCFTypeDictionaryValueCallBacks);
-    CPPUNIT_ASSERT(lAddedDictionaryRef != NULL);
-
-    lCommonDictionaryRef = CFDictionaryCreateMutable(kCFAllocatorDefault,
-                                                     0,
-                                                     &kCFTypeDictionaryKeyCallBacks,
-                                                     &kCFTypeDictionaryValueCallBacks);
-    CPPUNIT_ASSERT(lCommonDictionaryRef != NULL);
-
-    lRemovedDictionaryRef = CFDictionaryCreateMutable(kCFAllocatorDefault,
-                                                      0,
-                                                      &kCFTypeDictionaryKeyCallBacks,
-                                                      &kCFTypeDictionaryValueCallBacks);
-    CPPUNIT_ASSERT(lRemovedDictionaryRef != NULL);
+    TestSetup(lAddedDictionaryRef,
+              lCommonDictionaryRef,
+              lRemovedDictionaryRef);
 
     // Test the C binding.
 
@@ -87,15 +117,1383 @@ TestCFUDictionaryDifference :: TestNull(void)
                                       lRemovedDictionaryRef);
     CPPUNIT_ASSERT(lStatus == false);
 
-    if (lAddedDictionaryRef != NULL) {
-        CFRelease(lAddedDictionaryRef);
-    }
+    // Deallocate the added, common, and removed dictionaries
 
-    if (lCommonDictionaryRef != NULL) {
-        CFRelease(lCommonDictionaryRef);
-    }
+    TestTeardown(lAddedDictionaryRef,
+                 lCommonDictionaryRef,
+                 lRemovedDictionaryRef);
+}
 
-    if (lRemovedDictionaryRef != NULL) {
-        CFRelease(lRemovedDictionaryRef);
+void
+TestCFUDictionaryDifference :: TestEmptyProposed(void)
+{
+    constexpr size_t       kBaseKeyCount              = 2;
+    const void *           kBaseKeys[kBaseKeyCount]   = {
+        CFSTR("Test Key 2"),
+        CFSTR("Test Key 4")
+    };
+    const void *           kBaseValues[kBaseKeyCount] = {
+        CFSTR("Test Value 2"),
+        CFSTR("Test Value 4")
+    };
+    CFMutableDictionaryRef lAddedDictionaryRef    = nullptr;
+    CFMutableDictionaryRef lCommonDictionaryRef   = nullptr;
+    CFMutableDictionaryRef lRemovedDictionaryRef  = nullptr;
+    CFDictionaryRef        lProposedDictionaryRef = nullptr;
+    CFMutableDictionaryRef lBaseDictionaryRef     = nullptr;
+    Boolean                lStatus;
+
+    // Allocate the added, common, and removed dictionaries
+
+    TestSetup(lAddedDictionaryRef,
+              lCommonDictionaryRef,
+              lRemovedDictionaryRef);
+
+    // Allocate the base dictionary.
+
+    TestDictionaryCreateWithKeysAndValues(&kBaseKeys[0],
+                                          &kBaseValues[0],
+                                          kBaseKeyCount,
+                                          lBaseDictionaryRef);
+    CPPUNIT_ASSERT(lBaseDictionaryRef != nullptr);
+
+    // Allocate the proposed dictionary.
+
+    TestDictionaryCreateWithKeysAndValues(nullptr,
+                                          nullptr,
+                                          0,
+                                          lProposedDictionaryRef);
+    CPPUNIT_ASSERT(lProposedDictionaryRef != nullptr);
+
+    // Perform the difference.
+
+    lStatus = CFUDictionaryDifference(lProposedDictionaryRef,
+                                      lBaseDictionaryRef,
+                                      lAddedDictionaryRef,
+                                      lCommonDictionaryRef,
+                                      lRemovedDictionaryRef);
+    CPPUNIT_ASSERT(lStatus == true);
+
+    // Check that we have the expected number of and key/value pairs
+    // in the added dictionary.
+    //
+    // In this case, zero (0).
+
+    TestDictionaryKeysAndValues(lAddedDictionaryRef,
+                                nullptr,
+                                nullptr,
+                                0);
+
+    // Check that we have the expected number of and key/value pairs
+    // in the common dictionary.
+    //
+    // In this case, zero (0).
+
+    TestDictionaryKeysAndValues(lCommonDictionaryRef,
+                                nullptr,
+                                nullptr,
+                                0);
+
+    // Check that we have the expected number of and key/value pairs
+    // in the removed dictionary.
+    //
+    // In this case, two (2), since the proposed has no entries
+    // relative to the base two entries.
+
+    TestDictionaryKeysAndValues(lRemovedDictionaryRef,
+                                &kBaseKeys[0],
+                                &kBaseValues[0],
+                                kBaseKeyCount);
+
+    // Deallocate the base and proposed dictionaries.
+
+    CFRelease(lProposedDictionaryRef);
+    CFRelease(lBaseDictionaryRef);
+
+    // Deallocate the added, common, and removed dictionaries
+
+    TestTeardown(lAddedDictionaryRef,
+                 lCommonDictionaryRef,
+                 lRemovedDictionaryRef);
+}
+
+void
+TestCFUDictionaryDifference :: TestEmptyBase(void)
+{
+    constexpr size_t       kProposedKeyCount                  = 2;
+    const void *           kProposedKeys[kProposedKeyCount]   = {
+        CFSTR("Test Key 1"),
+        CFSTR("Test Key 3")
+    };
+    const void *           kProposedValues[kProposedKeyCount] = {
+        CFSTR("Test Value 1"),
+        CFSTR("Test Value 3")
+    };
+    CFMutableDictionaryRef lAddedDictionaryRef    = nullptr;
+    CFMutableDictionaryRef lCommonDictionaryRef   = nullptr;
+    CFMutableDictionaryRef lRemovedDictionaryRef  = nullptr;
+    CFDictionaryRef        lProposedDictionaryRef = nullptr;
+    CFMutableDictionaryRef lBaseDictionaryRef     = nullptr;
+    Boolean                lStatus;
+
+    // Allocate the added, common, and removed dictionaries
+
+    TestSetup(lAddedDictionaryRef,
+              lCommonDictionaryRef,
+              lRemovedDictionaryRef);
+
+    // Allocate the base dictionary.
+
+    TestDictionaryCreateWithKeysAndValues(nullptr,
+                                          nullptr,
+                                          0,
+                                          lBaseDictionaryRef);
+    CPPUNIT_ASSERT(lBaseDictionaryRef != nullptr);
+
+    // Allocate the proposed dictionary.
+
+    TestDictionaryCreateWithKeysAndValues(&kProposedKeys[0],
+                                          &kProposedValues[0],
+                                          kProposedKeyCount,
+                                          lProposedDictionaryRef);
+    CPPUNIT_ASSERT(lProposedDictionaryRef != nullptr);
+
+    // Perform the difference.
+
+    lStatus = CFUDictionaryDifference(lProposedDictionaryRef,
+                                      lBaseDictionaryRef,
+                                      lAddedDictionaryRef,
+                                      lCommonDictionaryRef,
+                                      lRemovedDictionaryRef);
+    CPPUNIT_ASSERT(lStatus == true);
+
+    // Check that we have the expected number of and key/value pairs
+    // in the added dictionary.
+    //
+    // In this case, two (2), since the proposed has two entries
+    // relative to the base no entries.
+
+    TestDictionaryKeysAndValues(lAddedDictionaryRef,
+                                &kProposedKeys[0],
+                                &kProposedValues[0],
+                                kProposedKeyCount);
+
+    // Check that we have the expected number of and key/value pairs
+    // in the common dictionary.
+    //
+    // In this case, zero (0).
+
+    TestDictionaryKeysAndValues(lCommonDictionaryRef,
+                                nullptr,
+                                nullptr,
+                                0);
+
+    // Check that we have the expected number of and key/value pairs
+    // in the removed dictionary.
+    //
+    // In this case, zero (0).
+
+    TestDictionaryKeysAndValues(lRemovedDictionaryRef,
+                                nullptr,
+                                nullptr,
+                                0);
+
+    // Deallocate the base and proposed dictionaries.
+
+    CFRelease(lProposedDictionaryRef);
+    CFRelease(lBaseDictionaryRef);
+
+    // Deallocate the added, common, and removed dictionaries
+
+    TestTeardown(lAddedDictionaryRef,
+                 lCommonDictionaryRef,
+                 lRemovedDictionaryRef);
+}
+
+void
+TestCFUDictionaryDifference :: TestIdenticalBaseAndProposed(void)
+{
+    constexpr size_t       kCommonKeyCount                = 2;
+    const void *           kCommonKeys[kCommonKeyCount]   = {
+        CFSTR("Test Key 5"),
+        CFSTR("Test Key 6")
+    };
+    const void *           kCommonValues[kCommonKeyCount] = {
+        CFSTR("Test Value 5"),
+        CFSTR("Test Value 6")
+    };
+    CFMutableDictionaryRef lAddedDictionaryRef    = nullptr;
+    CFMutableDictionaryRef lCommonDictionaryRef   = nullptr;
+    CFMutableDictionaryRef lRemovedDictionaryRef  = nullptr;
+    CFDictionaryRef        lProposedDictionaryRef = nullptr;
+    CFMutableDictionaryRef lBaseDictionaryRef     = nullptr;
+    Boolean                lStatus;
+
+    // Allocate the added, common, and removed dictionaries
+
+    TestSetup(lAddedDictionaryRef,
+              lCommonDictionaryRef,
+              lRemovedDictionaryRef);
+
+    // Allocate the base dictionary.
+
+    TestDictionaryCreateWithKeysAndValues(&kCommonKeys[0],
+                                          &kCommonValues[0],
+                                          kCommonKeyCount,
+                                          lBaseDictionaryRef);
+    CPPUNIT_ASSERT(lBaseDictionaryRef != nullptr);
+
+    // Allocate the proposed dictionary.
+
+    TestDictionaryCreateWithKeysAndValues(&kCommonKeys[0],
+                                          &kCommonValues[0],
+                                          kCommonKeyCount,
+                                          lProposedDictionaryRef);
+    CPPUNIT_ASSERT(lProposedDictionaryRef != nullptr);
+
+    // Perform the difference.
+
+    lStatus = CFUDictionaryDifference(lProposedDictionaryRef,
+                                      lBaseDictionaryRef,
+                                      lAddedDictionaryRef,
+                                      lCommonDictionaryRef,
+                                      lRemovedDictionaryRef);
+    CPPUNIT_ASSERT(lStatus == true);
+
+    // Check that we have the expected number of and key/value pairs
+    // in the added dictionary.
+    //
+    // In this case, zero (0).
+
+    TestDictionaryKeysAndValues(lAddedDictionaryRef,
+                                nullptr,
+                                nullptr,
+                                0);
+
+    // Check that we have the expected number of and key/value pairs
+    // in the common dictionary.
+    //
+    // In this case, two (2), since the proposed and base entries are
+    // the same identical set of two.
+
+    TestDictionaryKeysAndValues(lCommonDictionaryRef,
+                                &kCommonKeys[0],
+                                &kCommonValues[0],
+                                kCommonKeyCount);
+
+    // Check that we have the expected number of and key/value pairs
+    // in the removed dictionary.
+    //
+    // In this case, zero (0).
+
+    TestDictionaryKeysAndValues(lRemovedDictionaryRef,
+                                nullptr,
+                                nullptr,
+                                0);
+
+    // Deallocate the base and proposed dictionaries.
+
+    CFRelease(lProposedDictionaryRef);
+    CFRelease(lBaseDictionaryRef);
+
+    // Deallocate the added, common, and removed dictionaries
+
+    TestTeardown(lAddedDictionaryRef,
+                 lCommonDictionaryRef,
+                 lRemovedDictionaryRef);
+}
+
+void
+TestCFUDictionaryDifference :: TestDisjointBaseAndProposed(void)
+{
+    constexpr size_t       kBaseKeyCount                      = 2;
+    const void *           kBaseKeys[kBaseKeyCount]           = {
+        CFSTR("Test Key 2"),
+        CFSTR("Test Key 4")
+    };
+    const void *           kBaseValues[kBaseKeyCount]         = {
+        CFSTR("Test Value 2"),
+        CFSTR("Test Value 4")
+    };
+    constexpr size_t       kProposedKeyCount                  = 2;
+    const void *           kProposedKeys[kProposedKeyCount]   = {
+        CFSTR("Test Key 1"),
+        CFSTR("Test Key 3")
+    };
+    const void *           kProposedValues[kProposedKeyCount] = {
+        CFSTR("Test Value 1"),
+        CFSTR("Test Value 3")
+    };
+    CFMutableDictionaryRef lAddedDictionaryRef    = nullptr;
+    CFMutableDictionaryRef lCommonDictionaryRef   = nullptr;
+    CFMutableDictionaryRef lRemovedDictionaryRef  = nullptr;
+    CFDictionaryRef        lProposedDictionaryRef = nullptr;
+    CFMutableDictionaryRef lBaseDictionaryRef     = nullptr;
+    Boolean                lStatus;
+
+    // Allocate the added, common, and removed dictionaries
+
+    TestSetup(lAddedDictionaryRef,
+              lCommonDictionaryRef,
+              lRemovedDictionaryRef);
+
+    // Allocate the base dictionary.
+
+    TestDictionaryCreateWithKeysAndValues(&kBaseKeys[0],
+                                          &kBaseValues[0],
+                                          kBaseKeyCount,
+                                          lBaseDictionaryRef);
+    CPPUNIT_ASSERT(lBaseDictionaryRef != nullptr);
+
+    // Allocate the proposed dictionary.
+
+    TestDictionaryCreateWithKeysAndValues(&kProposedKeys[0],
+                                          &kProposedValues[0],
+                                          kProposedKeyCount,
+                                          lProposedDictionaryRef);
+    CPPUNIT_ASSERT(lProposedDictionaryRef != nullptr);
+
+    // Perform the difference.
+
+    lStatus = CFUDictionaryDifference(lProposedDictionaryRef,
+                                      lBaseDictionaryRef,
+                                      lAddedDictionaryRef,
+                                      lCommonDictionaryRef,
+                                      lRemovedDictionaryRef);
+    CPPUNIT_ASSERT(lStatus == true);
+
+    // Check that we have the expected number of and key/value pairs
+    // in the added dictionary.
+    //
+    // In this case, two (2), since the proposed has two disjoint entries
+    // relative to the base two entries.
+
+    TestDictionaryKeysAndValues(lAddedDictionaryRef,
+                                &kProposedKeys[0],
+                                &kProposedValues[0],
+                                kProposedKeyCount);
+
+    // Check that we have the expected number of and key/value pairs
+    // in the common dictionary.
+    //
+    // In this case, zero (0).
+
+    TestDictionaryKeysAndValues(lCommonDictionaryRef,
+                                nullptr,
+                                nullptr,
+                                0);
+
+    // Check that we have the expected number of and key/value pairs
+    // in the removed dictionary.
+    //
+    // In this case, two (2), since the base has two disjoint entries
+    // relative to the proposed two entries.
+
+    TestDictionaryKeysAndValues(lRemovedDictionaryRef,
+                                &kBaseKeys[0],
+                                &kBaseValues[0],
+                                kBaseKeyCount);
+
+    // Deallocate the base and proposed dictionaries.
+
+    CFRelease(lProposedDictionaryRef);
+    CFRelease(lBaseDictionaryRef);
+
+    // Deallocate the added, common, and removed dictionaries
+
+    TestTeardown(lAddedDictionaryRef,
+                 lCommonDictionaryRef,
+                 lRemovedDictionaryRef);
+}
+
+void
+TestCFUDictionaryDifference :: TestBaseIsStrictSubsetOfProposed(void)
+{
+    constexpr size_t       kBaseKeyCount                      = 2;
+    const void *           kBaseKeys[kBaseKeyCount]           = {
+        CFSTR("Test Key 1"),
+        CFSTR("Test Key 3")
+    };
+    const void *           kBaseValues[kBaseKeyCount]         = {
+        CFSTR("Test Value 1"),
+        CFSTR("Test Value 3")
+    };
+    constexpr size_t       kProposedKeyCount                  = 3;
+    const void *           kProposedKeys[kProposedKeyCount]   = {
+        CFSTR("Test Key 1"),
+        CFSTR("Test Key 3"),
+        CFSTR("Test Key 7"),
+    };
+    const void *           kProposedValues[kProposedKeyCount] = {
+        CFSTR("Test Value 1"),
+        CFSTR("Test Value 3"),
+        CFSTR("Test Value 7")
+    };
+    CFMutableDictionaryRef lAddedDictionaryRef    = nullptr;
+    CFMutableDictionaryRef lCommonDictionaryRef   = nullptr;
+    CFMutableDictionaryRef lRemovedDictionaryRef  = nullptr;
+    CFDictionaryRef        lProposedDictionaryRef = nullptr;
+    CFMutableDictionaryRef lBaseDictionaryRef     = nullptr;
+    Boolean                lStatus;
+
+    // Allocate the added, common, and removed dictionaries
+
+    TestSetup(lAddedDictionaryRef,
+              lCommonDictionaryRef,
+              lRemovedDictionaryRef);
+
+    // Allocate the base dictionary.
+
+    TestDictionaryCreateWithKeysAndValues(&kBaseKeys[0],
+                                          &kBaseValues[0],
+                                          kBaseKeyCount,
+                                          lBaseDictionaryRef);
+    CPPUNIT_ASSERT(lBaseDictionaryRef != nullptr);
+
+    // Allocate the proposed dictionary.
+
+    TestDictionaryCreateWithKeysAndValues(&kProposedKeys[0],
+                                          &kProposedValues[0],
+                                          kProposedKeyCount,
+                                          lProposedDictionaryRef);
+    CPPUNIT_ASSERT(lProposedDictionaryRef != nullptr);
+
+    // Perform the difference.
+
+    lStatus = CFUDictionaryDifference(lProposedDictionaryRef,
+                                      lBaseDictionaryRef,
+                                      lAddedDictionaryRef,
+                                      lCommonDictionaryRef,
+                                      lRemovedDictionaryRef);
+    CPPUNIT_ASSERT(lStatus == true);
+
+    // Check that we have the expected number of and key/value pairs
+    // in the added dictionary.
+    //
+    // In this case, one (1), since the proposed is strictly a
+    // superset of the base with a single unique entry.
+
+    TestDictionaryKeysAndValues(lAddedDictionaryRef,
+                                &kProposedKeys[kProposedKeyCount - 1],
+                                &kProposedValues[kProposedKeyCount - 1],
+                                kProposedKeyCount - kBaseKeyCount);
+
+    // Check that we have the expected number of and key/value pairs
+    // in the common dictionary.
+    //
+    // In this case, two (2) since the proposed is strictly a superset
+    // of the base with two (2) common entries among them.
+
+    TestDictionaryKeysAndValues(lCommonDictionaryRef,
+                                &kBaseKeys[0],
+                                &kBaseValues[0],
+                                kBaseKeyCount);
+
+    // Check that we have the expected number of and key/value pairs
+    // in the removed dictionary.
+    //
+    // In this case, zero (0), since the proposed is strictly a
+    // superset of the base.
+
+    TestDictionaryKeysAndValues(lRemovedDictionaryRef,
+                                nullptr,
+                                nullptr,
+                                0);
+
+    // Deallocate the base and proposed dictionaries.
+
+    CFRelease(lProposedDictionaryRef);
+    CFRelease(lBaseDictionaryRef);
+
+    // Deallocate the added, common, and removed dictionaries
+
+    TestTeardown(lAddedDictionaryRef,
+                 lCommonDictionaryRef,
+                 lRemovedDictionaryRef);
+}
+
+void
+TestCFUDictionaryDifference :: TestBaseIsStrictSupersetOfProposed(void)
+{
+    constexpr size_t       kBaseKeyCount                      = 3;
+    const void *           kBaseKeys[kBaseKeyCount]           = {
+        CFSTR("Test Key 1"),
+        CFSTR("Test Key 3"),
+        CFSTR("Test Key 7")
+    };
+    const void *           kBaseValues[kBaseKeyCount]         = {
+        CFSTR("Test Value 1"),
+        CFSTR("Test Value 3"),
+        CFSTR("Test Value 7")
+    };
+    constexpr size_t       kProposedKeyCount                  = 2;
+    const void *           kProposedKeys[kProposedKeyCount]   = {
+        CFSTR("Test Key 1"),
+        CFSTR("Test Key 3"),
+
+    };
+    const void *           kProposedValues[kProposedKeyCount] = {
+        CFSTR("Test Value 1"),
+        CFSTR("Test Value 3")
+    };
+    CFMutableDictionaryRef lAddedDictionaryRef    = nullptr;
+    CFMutableDictionaryRef lCommonDictionaryRef   = nullptr;
+    CFMutableDictionaryRef lRemovedDictionaryRef  = nullptr;
+    CFDictionaryRef        lProposedDictionaryRef = nullptr;
+    CFMutableDictionaryRef lBaseDictionaryRef     = nullptr;
+    Boolean                lStatus;
+
+    // Allocate the added, common, and removed dictionaries
+
+    TestSetup(lAddedDictionaryRef,
+              lCommonDictionaryRef,
+              lRemovedDictionaryRef);
+
+    // Allocate the base dictionary.
+
+    TestDictionaryCreateWithKeysAndValues(&kBaseKeys[0],
+                                          &kBaseValues[0],
+                                          kBaseKeyCount,
+                                          lBaseDictionaryRef);
+    CPPUNIT_ASSERT(lBaseDictionaryRef != nullptr);
+
+    // Allocate the proposed dictionary.
+
+    TestDictionaryCreateWithKeysAndValues(&kProposedKeys[0],
+                                          &kProposedValues[0],
+                                          kProposedKeyCount,
+                                          lProposedDictionaryRef);
+    CPPUNIT_ASSERT(lProposedDictionaryRef != nullptr);
+
+    // Perform the difference.
+
+    lStatus = CFUDictionaryDifference(lProposedDictionaryRef,
+                                      lBaseDictionaryRef,
+                                      lAddedDictionaryRef,
+                                      lCommonDictionaryRef,
+                                      lRemovedDictionaryRef);
+    CPPUNIT_ASSERT(lStatus == true);
+
+    // Check that we have the expected number of and key/value pairs
+    // in the added dictionary.
+    //
+    // In this case, zero (0), since the base is strictly a
+    // superset of the proposed.
+
+    TestDictionaryKeysAndValues(lAddedDictionaryRef,
+                                nullptr,
+                                nullptr,
+                                0);
+
+    // Check that we have the expected number of and key/value pairs
+    // in the common dictionary.
+    //
+    // In this case, two (2) since the base is strictly a superset
+    // of the proposed with two (2) common entries among them.
+
+    TestDictionaryKeysAndValues(lCommonDictionaryRef,
+                                &kProposedKeys[0],
+                                &kProposedValues[0],
+                                kProposedKeyCount);
+
+    // Check that we have the expected number of and key/value pairs
+    // in the removed dictionary.
+    //
+    // In this case, one (1), since the base is strictly a
+    // superset of the proposed with a single unique entry.
+
+    TestDictionaryKeysAndValues(lRemovedDictionaryRef,
+                                &kBaseKeys[kBaseKeyCount - 1],
+                                &kBaseValues[kBaseKeyCount - 1],
+                                kBaseKeyCount - kProposedKeyCount);
+
+    // Deallocate the base and proposed dictionaries.
+
+    CFRelease(lProposedDictionaryRef);
+    CFRelease(lBaseDictionaryRef);
+
+    // Deallocate the added, common, and removed dictionaries
+
+    TestTeardown(lAddedDictionaryRef,
+                 lCommonDictionaryRef,
+                 lRemovedDictionaryRef);
+}
+
+void
+TestCFUDictionaryDifference :: TestBaseAndProposedDifferInCommonValuesAndHaveNoUniqueEntries(void)
+{
+    constexpr size_t       kBaseKeyCount                      = 2;
+    const void *           kBaseKeys[kBaseKeyCount]           = {
+        CFSTR("Test Key 8"),
+        CFSTR("Test Key 10")
+    };
+    const void *           kBaseValues[kBaseKeyCount]         = {
+        CFSTR("Test Value 8"),
+        CFSTR("Test Value 10")
+    };
+    constexpr size_t       kProposedKeyCount                  = 2;
+    const void *           kProposedKeys[kProposedKeyCount]   = {
+        CFSTR("Test Key 8"),
+        CFSTR("Test Key 10")
+    };
+    const void *           kProposedValues[kProposedKeyCount] = {
+        CFSTR("Test Value 12"),
+        CFSTR("Test Value 14")
+    };
+    CFMutableDictionaryRef lAddedDictionaryRef    = nullptr;
+    CFMutableDictionaryRef lCommonDictionaryRef   = nullptr;
+    CFMutableDictionaryRef lRemovedDictionaryRef  = nullptr;
+    CFDictionaryRef        lProposedDictionaryRef = nullptr;
+    CFMutableDictionaryRef lBaseDictionaryRef     = nullptr;
+    Boolean                lStatus;
+
+    // Allocate the added, common, and removed dictionaries
+
+    TestSetup(lAddedDictionaryRef,
+              lCommonDictionaryRef,
+              lRemovedDictionaryRef);
+
+    // Allocate the base dictionary.
+
+    TestDictionaryCreateWithKeysAndValues(&kBaseKeys[0],
+                                          &kBaseValues[0],
+                                          kBaseKeyCount,
+                                          lBaseDictionaryRef);
+    CPPUNIT_ASSERT(lBaseDictionaryRef != nullptr);
+
+    // Allocate the proposed dictionary.
+
+    TestDictionaryCreateWithKeysAndValues(&kProposedKeys[0],
+                                          &kProposedValues[0],
+                                          kProposedKeyCount,
+                                          lProposedDictionaryRef);
+    CPPUNIT_ASSERT(lProposedDictionaryRef != nullptr);
+
+    // Perform the difference.
+
+    lStatus = CFUDictionaryDifference(lProposedDictionaryRef,
+                                      lBaseDictionaryRef,
+                                      lAddedDictionaryRef,
+                                      lCommonDictionaryRef,
+                                      lRemovedDictionaryRef);
+    CPPUNIT_ASSERT(lStatus == true);
+
+    // Check that we have the expected number of and key/value pairs
+    // in the added dictionary.
+    //
+    // In this case, zero (0), since the base and proposed share
+    // common keys but different values.
+
+    TestDictionaryKeysAndValues(lAddedDictionaryRef,
+                                nullptr,
+                                nullptr,
+                                0);
+
+    // Check that we have the expected number of and key/value pairs
+    // in the common dictionary.
+    //
+    // In this case, two (2), since the base and proposed have common
+    // keys but different values.
+
+    TestDictionaryKeysAndValues(lCommonDictionaryRef,
+                                &kBaseKeys[0],
+                                &kBaseValues[0],
+                                kBaseKeyCount);
+
+    // Check that we have the expected number of and key/value pairs
+    // in the removed dictionary.
+    //
+    // In this case, zero (0), since the base and proposed share
+    // common keys but different values.
+
+    TestDictionaryKeysAndValues(lRemovedDictionaryRef,
+                                nullptr,
+                                nullptr,
+                                0);
+
+    // Deallocate the base and proposed dictionaries.
+
+    CFRelease(lProposedDictionaryRef);
+    CFRelease(lBaseDictionaryRef);
+
+    // Deallocate the added, common, and removed dictionaries
+
+    TestTeardown(lAddedDictionaryRef,
+                 lCommonDictionaryRef,
+                 lRemovedDictionaryRef);
+}
+
+void
+TestCFUDictionaryDifference :: TestBaseAndProposedDifferInCommonValuesAndHaveUniqueEntries(void)
+{
+    constexpr size_t       kBaseKeyCount                      = 4;
+    const void *           kBaseKeys[kBaseKeyCount]           = {
+        CFSTR("Test Key 2"),
+        CFSTR("Test Key 4"),
+        CFSTR("Test Key 8"),
+        CFSTR("Test Key 10")
+    };
+    const void *           kBaseValues[kBaseKeyCount]         = {
+        CFSTR("Test Value 2"),
+        CFSTR("Test Value 4"),
+        CFSTR("Test Value 8"),
+        CFSTR("Test Value 10")
+    };
+    constexpr size_t       kProposedKeyCount                  = 4;
+    const void *           kProposedKeys[kProposedKeyCount]   = {
+        CFSTR("Test Key 1"),
+        CFSTR("Test Key 3"),
+        CFSTR("Test Key 8"),
+        CFSTR("Test Key 10")
+    };
+    const void *           kProposedValues[kProposedKeyCount] = {
+        CFSTR("Test Value 1"),
+        CFSTR("Test Value 3"),
+        CFSTR("Test Value 12"),
+        CFSTR("Test Value 14")
+    };
+    CFMutableDictionaryRef lAddedDictionaryRef    = nullptr;
+    CFMutableDictionaryRef lCommonDictionaryRef   = nullptr;
+    CFMutableDictionaryRef lRemovedDictionaryRef  = nullptr;
+    CFDictionaryRef        lProposedDictionaryRef = nullptr;
+    CFMutableDictionaryRef lBaseDictionaryRef     = nullptr;
+    Boolean                lStatus;
+
+    // Allocate the added, common, and removed dictionaries
+
+    TestSetup(lAddedDictionaryRef,
+              lCommonDictionaryRef,
+              lRemovedDictionaryRef);
+
+    // Allocate the base dictionary.
+
+    TestDictionaryCreateWithKeysAndValues(&kBaseKeys[0],
+                                          &kBaseValues[0],
+                                          kBaseKeyCount,
+                                          lBaseDictionaryRef);
+    CPPUNIT_ASSERT(lBaseDictionaryRef != nullptr);
+
+    // Allocate the proposed dictionary.
+
+    TestDictionaryCreateWithKeysAndValues(&kProposedKeys[0],
+                                          &kProposedValues[0],
+                                          kProposedKeyCount,
+                                          lProposedDictionaryRef);
+    CPPUNIT_ASSERT(lProposedDictionaryRef != nullptr);
+
+    // Perform the difference.
+
+    lStatus = CFUDictionaryDifference(lProposedDictionaryRef,
+                                      lBaseDictionaryRef,
+                                      lAddedDictionaryRef,
+                                      lCommonDictionaryRef,
+                                      lRemovedDictionaryRef);
+    CPPUNIT_ASSERT(lStatus == true);
+
+    // Check that we have the expected number of and key/value pairs
+    // in the added dictionary.
+    //
+    // In this case, two (2), since the proposed has two unique
+    // entries not present in the base in addition to their common
+    // keys.
+
+    TestDictionaryKeysAndValues(lAddedDictionaryRef,
+                                &kProposedKeys[0],
+                                &kProposedValues[0],
+                                2);
+
+    // Check that we have the expected number of and key/value pairs
+    // in the common dictionary.
+    //
+    // In this case, two (2), since the base and proposed have two (2)
+    // common keys but with different values.
+
+    TestDictionaryKeysAndValues(lCommonDictionaryRef,
+                                &kBaseKeys[2],
+                                &kBaseValues[2],
+                                2);
+
+    // Check that we have the expected number of and key/value pairs
+    // in the removed dictionary.
+    //
+    // In this case, two (2), since the base has two unique
+    // entries not present in the proposed in addition to their common
+    // keys.
+
+    TestDictionaryKeysAndValues(lRemovedDictionaryRef,
+                                &kBaseKeys[0],
+                                &kBaseValues[0],
+                                2);
+
+    // Deallocate the base and proposed dictionaries.
+
+    CFRelease(lProposedDictionaryRef);
+    CFRelease(lBaseDictionaryRef);
+
+    // Deallocate the added, common, and removed dictionaries
+
+    TestTeardown(lAddedDictionaryRef,
+                 lCommonDictionaryRef,
+                 lRemovedDictionaryRef);
+}
+
+void
+TestCFUDictionaryDifference :: TestBaseAndProposedHaveCommonValuesAndHaveUniqueEntries(void)
+{
+    constexpr size_t       kBaseKeyCount                      = 4;
+    const void *           kBaseKeys[kBaseKeyCount]           = {
+        CFSTR("Test Key 2"),
+        CFSTR("Test Key 4"),
+        CFSTR("Test Key 8"),
+        CFSTR("Test Key 10")
+    };
+    const void *           kBaseValues[kBaseKeyCount]         = {
+        CFSTR("Test Value 2"),
+        CFSTR("Test Value 4"),
+        CFSTR("Test Value 8"),
+        CFSTR("Test Value 10")
+    };
+    constexpr size_t       kProposedKeyCount                  = 4;
+    const void *           kProposedKeys[kProposedKeyCount]   = {
+        CFSTR("Test Key 1"),
+        CFSTR("Test Key 3"),
+        CFSTR("Test Key 8"),
+        CFSTR("Test Key 10")
+    };
+    const void *           kProposedValues[kProposedKeyCount] = {
+        CFSTR("Test Value 1"),
+        CFSTR("Test Value 3"),
+        CFSTR("Test Value 8"),
+        CFSTR("Test Value 10")
+    };
+    CFMutableDictionaryRef lAddedDictionaryRef    = nullptr;
+    CFMutableDictionaryRef lCommonDictionaryRef   = nullptr;
+    CFMutableDictionaryRef lRemovedDictionaryRef  = nullptr;
+    CFDictionaryRef        lProposedDictionaryRef = nullptr;
+    CFMutableDictionaryRef lBaseDictionaryRef     = nullptr;
+    Boolean                lStatus;
+
+    // Allocate the added, common, and removed dictionaries
+
+    TestSetup(lAddedDictionaryRef,
+              lCommonDictionaryRef,
+              lRemovedDictionaryRef);
+
+    // Allocate the base dictionary.
+
+    TestDictionaryCreateWithKeysAndValues(&kBaseKeys[0],
+                                          &kBaseValues[0],
+                                          kBaseKeyCount,
+                                          lBaseDictionaryRef);
+    CPPUNIT_ASSERT(lBaseDictionaryRef != nullptr);
+
+    // Allocate the proposed dictionary.
+
+    TestDictionaryCreateWithKeysAndValues(&kProposedKeys[0],
+                                          &kProposedValues[0],
+                                          kProposedKeyCount,
+                                          lProposedDictionaryRef);
+    CPPUNIT_ASSERT(lProposedDictionaryRef != nullptr);
+
+    // Perform the difference.
+
+    lStatus = CFUDictionaryDifference(lProposedDictionaryRef,
+                                      lBaseDictionaryRef,
+                                      lAddedDictionaryRef,
+                                      lCommonDictionaryRef,
+                                      lRemovedDictionaryRef);
+    CPPUNIT_ASSERT(lStatus == true);
+
+    // Check that we have the expected number of and key/value pairs
+    // in the added dictionary.
+    //
+    // In this case, two (2), since the proposed has two unique
+    // entries not present in the base in addition to their common
+    // keys.
+
+    TestDictionaryKeysAndValues(lAddedDictionaryRef,
+                                &kProposedKeys[0],
+                                &kProposedValues[0],
+                                2);
+
+    // Check that we have the expected number of and key/value pairs
+    // in the common dictionary.
+    //
+    // In this case, two (2), since the base and proposed have two (2)
+    // common keys.
+
+    TestDictionaryKeysAndValues(lCommonDictionaryRef,
+                                &kBaseKeys[2],
+                                &kBaseValues[2],
+                                2);
+
+    // Check that we have the expected number of and key/value pairs
+    // in the removed dictionary.
+    //
+    // In this case, two (2), since the base has two unique
+    // entries not present in the proposed in addition to their common
+    // keys.
+
+    TestDictionaryKeysAndValues(lRemovedDictionaryRef,
+                                &kBaseKeys[0],
+                                &kBaseValues[0],
+                                2);
+
+    // Deallocate the base and proposed dictionaries.
+
+    CFRelease(lProposedDictionaryRef);
+    CFRelease(lBaseDictionaryRef);
+
+    // Deallocate the added, common, and removed dictionaries
+
+    TestTeardown(lAddedDictionaryRef,
+                 lCommonDictionaryRef,
+                 lRemovedDictionaryRef);
+}
+
+void
+TestCFUDictionaryDifference :: TestBaseAndProposedHaveCommonValuesAndHaveUniqueEntriesAddedResultsOnly(void)
+{
+    constexpr size_t       kBaseKeyCount                      = 4;
+    const void *           kBaseKeys[kBaseKeyCount]           = {
+        CFSTR("Test Key 2"),
+        CFSTR("Test Key 4"),
+        CFSTR("Test Key 8"),
+        CFSTR("Test Key 10")
+    };
+    const void *           kBaseValues[kBaseKeyCount]         = {
+        CFSTR("Test Value 2"),
+        CFSTR("Test Value 4"),
+        CFSTR("Test Value 8"),
+        CFSTR("Test Value 10")
+    };
+    constexpr size_t       kProposedKeyCount                  = 4;
+    const void *           kProposedKeys[kProposedKeyCount]   = {
+        CFSTR("Test Key 1"),
+        CFSTR("Test Key 3"),
+        CFSTR("Test Key 8"),
+        CFSTR("Test Key 10")
+    };
+    const void *           kProposedValues[kProposedKeyCount] = {
+        CFSTR("Test Value 1"),
+        CFSTR("Test Value 3"),
+        CFSTR("Test Value 8"),
+        CFSTR("Test Value 10")
+    };
+    CFMutableDictionaryRef lAddedDictionaryRef    = nullptr;
+    CFMutableDictionaryRef lCommonDictionaryRef   = nullptr;
+    CFMutableDictionaryRef lRemovedDictionaryRef  = nullptr;
+    CFDictionaryRef        lProposedDictionaryRef = nullptr;
+    CFMutableDictionaryRef lBaseDictionaryRef     = nullptr;
+    Boolean                lStatus;
+
+    // Allocate the added, common, and removed dictionaries
+
+    TestSetup(lAddedDictionaryRef,
+              lCommonDictionaryRef,
+              lRemovedDictionaryRef);
+
+    // Allocate the base dictionary.
+
+    TestDictionaryCreateWithKeysAndValues(&kBaseKeys[0],
+                                          &kBaseValues[0],
+                                          kBaseKeyCount,
+                                          lBaseDictionaryRef);
+    CPPUNIT_ASSERT(lBaseDictionaryRef != nullptr);
+
+    // Allocate the proposed dictionary.
+
+    TestDictionaryCreateWithKeysAndValues(&kProposedKeys[0],
+                                          &kProposedValues[0],
+                                          kProposedKeyCount,
+                                          lProposedDictionaryRef);
+    CPPUNIT_ASSERT(lProposedDictionaryRef != nullptr);
+
+    // Perform the difference.
+
+    lStatus = CFUDictionaryDifference(lProposedDictionaryRef,
+                                      lBaseDictionaryRef,
+                                      lAddedDictionaryRef,
+                                      nullptr,
+                                      nullptr);
+    CPPUNIT_ASSERT(lStatus == true);
+
+    // Check that we have the expected number of and key/value pairs
+    // in the added dictionary.
+    //
+    // In this case, two (2), since the proposed has two unique
+    // entries not present in the base in addition to their common
+    // keys.
+
+    TestDictionaryKeysAndValues(lAddedDictionaryRef,
+                                &kProposedKeys[0],
+                                &kProposedValues[0],
+                                2);
+
+    // Check that we have the expected number of and key/value pairs
+    // in the common dictionary.
+    //
+    // In this case, zero (0), since no common dictionary was passed
+    // to the difference interface.
+
+    TestDictionaryKeysAndValues(lCommonDictionaryRef,
+                                nullptr,
+                                nullptr,
+                                0);
+
+    // Check that we have the expected number of and key/value pairs
+    // in the removed dictionary.
+    //
+    // In this case, zero (0), since no removed dictionary was passed
+    // to the difference interface.
+
+    TestDictionaryKeysAndValues(lRemovedDictionaryRef,
+                                nullptr,
+                                nullptr,
+                                0);
+
+    // Deallocate the base and proposed dictionaries.
+
+    CFRelease(lProposedDictionaryRef);
+    CFRelease(lBaseDictionaryRef);
+
+    // Deallocate the added, common, and removed dictionaries
+
+    TestTeardown(lAddedDictionaryRef,
+                 lCommonDictionaryRef,
+                 lRemovedDictionaryRef);
+}
+
+void
+TestCFUDictionaryDifference :: TestBaseAndProposedHaveCommonValuesAndHaveUniqueEntriesCommonResultsOnly(void)
+{
+    constexpr size_t       kBaseKeyCount                      = 4;
+    const void *           kBaseKeys[kBaseKeyCount]           = {
+        CFSTR("Test Key 2"),
+        CFSTR("Test Key 4"),
+        CFSTR("Test Key 8"),
+        CFSTR("Test Key 10")
+    };
+    const void *           kBaseValues[kBaseKeyCount]         = {
+        CFSTR("Test Value 2"),
+        CFSTR("Test Value 4"),
+        CFSTR("Test Value 8"),
+        CFSTR("Test Value 10")
+    };
+    constexpr size_t       kProposedKeyCount                  = 4;
+    const void *           kProposedKeys[kProposedKeyCount]   = {
+        CFSTR("Test Key 1"),
+        CFSTR("Test Key 3"),
+        CFSTR("Test Key 8"),
+        CFSTR("Test Key 10")
+    };
+    const void *           kProposedValues[kProposedKeyCount] = {
+        CFSTR("Test Value 1"),
+        CFSTR("Test Value 3"),
+        CFSTR("Test Value 8"),
+        CFSTR("Test Value 10")
+    };
+    CFMutableDictionaryRef lAddedDictionaryRef    = nullptr;
+    CFMutableDictionaryRef lCommonDictionaryRef   = nullptr;
+    CFMutableDictionaryRef lRemovedDictionaryRef  = nullptr;
+    CFDictionaryRef        lProposedDictionaryRef = nullptr;
+    CFMutableDictionaryRef lBaseDictionaryRef     = nullptr;
+    Boolean                lStatus;
+
+    // Allocate the added, common, and removed dictionaries
+
+    TestSetup(lAddedDictionaryRef,
+              lCommonDictionaryRef,
+              lRemovedDictionaryRef);
+
+    // Allocate the base dictionary.
+
+    TestDictionaryCreateWithKeysAndValues(&kBaseKeys[0],
+                                          &kBaseValues[0],
+                                          kBaseKeyCount,
+                                          lBaseDictionaryRef);
+    CPPUNIT_ASSERT(lBaseDictionaryRef != nullptr);
+
+    // Allocate the proposed dictionary.
+
+    TestDictionaryCreateWithKeysAndValues(&kProposedKeys[0],
+                                          &kProposedValues[0],
+                                          kProposedKeyCount,
+                                          lProposedDictionaryRef);
+    CPPUNIT_ASSERT(lProposedDictionaryRef != nullptr);
+
+    // Perform the difference.
+
+    lStatus = CFUDictionaryDifference(lProposedDictionaryRef,
+                                      lBaseDictionaryRef,
+                                      nullptr,
+                                      lCommonDictionaryRef,
+                                      nullptr);
+    CPPUNIT_ASSERT(lStatus == true);
+
+    // Check that we have the expected number of and key/value pairs
+    // in the added dictionary.
+    //
+    // In this case, zero (0), since no added dictionary was passed
+    // to the difference interface.
+
+    TestDictionaryKeysAndValues(lAddedDictionaryRef,
+                                nullptr,
+                                nullptr,
+                                0);
+
+    // Check that we have the expected number of and key/value pairs
+    // in the common dictionary.
+    //
+    // In this case, two (2), since the base and proposed have two (2)
+    // common keys.
+
+    TestDictionaryKeysAndValues(lCommonDictionaryRef,
+                                &kBaseKeys[2],
+                                &kBaseValues[2],
+                                2);
+
+    // Check that we have the expected number of and key/value pairs
+    // in the removed dictionary.
+    //
+    // In this case, zero (0), since no removed dictionary was passed
+    // to the difference interface.
+
+    TestDictionaryKeysAndValues(lRemovedDictionaryRef,
+                                nullptr,
+                                nullptr,
+                                0);
+
+    // Deallocate the base and proposed dictionaries.
+
+    CFRelease(lProposedDictionaryRef);
+    CFRelease(lBaseDictionaryRef);
+
+    // Deallocate the added, common, and removed dictionaries
+
+    TestTeardown(lAddedDictionaryRef,
+                 lCommonDictionaryRef,
+                 lRemovedDictionaryRef);
+}
+
+void
+TestCFUDictionaryDifference :: TestBaseAndProposedHaveCommonValuesAndHaveUniqueEntriesRemovedResultsOnly(void)
+{
+    constexpr size_t       kBaseKeyCount                      = 4;
+    const void *           kBaseKeys[kBaseKeyCount]           = {
+        CFSTR("Test Key 2"),
+        CFSTR("Test Key 4"),
+        CFSTR("Test Key 8"),
+        CFSTR("Test Key 10")
+    };
+    const void *           kBaseValues[kBaseKeyCount]         = {
+        CFSTR("Test Value 2"),
+        CFSTR("Test Value 4"),
+        CFSTR("Test Value 8"),
+        CFSTR("Test Value 10")
+    };
+    constexpr size_t       kProposedKeyCount                  = 4;
+    const void *           kProposedKeys[kProposedKeyCount]   = {
+        CFSTR("Test Key 1"),
+        CFSTR("Test Key 3"),
+        CFSTR("Test Key 8"),
+        CFSTR("Test Key 10")
+    };
+    const void *           kProposedValues[kProposedKeyCount] = {
+        CFSTR("Test Value 1"),
+        CFSTR("Test Value 3"),
+        CFSTR("Test Value 8"),
+        CFSTR("Test Value 10")
+    };
+    CFMutableDictionaryRef lAddedDictionaryRef    = nullptr;
+    CFMutableDictionaryRef lCommonDictionaryRef   = nullptr;
+    CFMutableDictionaryRef lRemovedDictionaryRef  = nullptr;
+    CFDictionaryRef        lProposedDictionaryRef = nullptr;
+    CFMutableDictionaryRef lBaseDictionaryRef     = nullptr;
+    Boolean                lStatus;
+
+    // Allocate the added, common, and removed dictionaries
+
+    TestSetup(lAddedDictionaryRef,
+              lCommonDictionaryRef,
+              lRemovedDictionaryRef);
+
+    // Allocate the base dictionary.
+
+    TestDictionaryCreateWithKeysAndValues(&kBaseKeys[0],
+                                          &kBaseValues[0],
+                                          kBaseKeyCount,
+                                          lBaseDictionaryRef);
+    CPPUNIT_ASSERT(lBaseDictionaryRef != nullptr);
+
+    // Allocate the proposed dictionary.
+
+    TestDictionaryCreateWithKeysAndValues(&kProposedKeys[0],
+                                          &kProposedValues[0],
+                                          kProposedKeyCount,
+                                          lProposedDictionaryRef);
+    CPPUNIT_ASSERT(lProposedDictionaryRef != nullptr);
+
+    // Perform the difference.
+
+    lStatus = CFUDictionaryDifference(lProposedDictionaryRef,
+                                      lBaseDictionaryRef,
+                                      nullptr,
+                                      nullptr,
+                                      lRemovedDictionaryRef);
+    CPPUNIT_ASSERT(lStatus == true);
+
+    // Check that we have the expected number of and key/value pairs
+    // in the added dictionary.
+    //
+    // In this case, zero (0), since no added dictionary was passed
+    // to the difference interface.
+
+    TestDictionaryKeysAndValues(lAddedDictionaryRef,
+                                nullptr,
+                                nullptr,
+                                0);
+
+    // Check that we have the expected number of and key/value pairs
+    // in the common dictionary.
+    //
+    // In this case, zero (0), since no common dictionary was passed
+    // to the difference interface.
+
+    TestDictionaryKeysAndValues(lCommonDictionaryRef,
+                                nullptr,
+                                nullptr,
+                                0);
+
+    // Check that we have the expected number of and key/value pairs
+    // in the removed dictionary.
+    //
+    // In this case, two (2), since the base has two unique
+    // entries not present in the proposed in addition to their common
+    // keys.
+
+    TestDictionaryKeysAndValues(lRemovedDictionaryRef,
+                                &kBaseKeys[0],
+                                &kBaseValues[0],
+                                2);
+
+    // Deallocate the base and proposed dictionaries.
+
+    CFRelease(lProposedDictionaryRef);
+    CFRelease(lBaseDictionaryRef);
+
+    // Deallocate the added, common, and removed dictionaries
+
+    TestTeardown(lAddedDictionaryRef,
+                 lCommonDictionaryRef,
+                 lRemovedDictionaryRef);
+}
+
+void
+TestCFUDictionaryDifference :: TestDictionaryCreateWithKeysAndValues(const void **inFirstKey,
+                                                                     const void **inFirstValue,
+                                                                     const size_t &inCount,
+                                                                     CFDictionaryRef &outDictionary)
+{
+    CPPUNIT_ASSERT(outDictionary == nullptr);
+
+    outDictionary = CFDictionaryCreate(kCFAllocatorDefault,
+                                       inFirstKey,
+                                       inFirstValue,
+                                       inCount,
+                                       &kCFTypeDictionaryKeyCallBacks,
+                                       &kCFTypeDictionaryValueCallBacks);
+    CPPUNIT_ASSERT(outDictionary != nullptr);
+}
+
+void
+TestCFUDictionaryDifference :: TestDictionaryCreateWithKeysAndValues(const void **inFirstKey,
+                                                                     const void **inFirstValue,
+                                                                     const size_t &inCount,
+                                                                     CFMutableDictionaryRef &outDictionary)
+{
+    CPPUNIT_ASSERT(outDictionary == nullptr);
+
+    outDictionary = CFDictionaryCreateMutable(kCFAllocatorDefault,
+                                              0,
+                                              &kCFTypeDictionaryKeyCallBacks,
+                                              &kCFTypeDictionaryValueCallBacks);
+    CPPUNIT_ASSERT(outDictionary != nullptr);
+
+    for (size_t i = 0; i < inCount; i++)
+    {
+        CFDictionaryAddValue(outDictionary, inFirstKey[i], inFirstValue[i]);
     }
+}
+
+void
+TestCFUDictionaryDifference :: TestSetup(CFMutableDictionaryRef &outAdded,
+                                         CFMutableDictionaryRef &outCommon,
+                                         CFMutableDictionaryRef &outRemoved)
+{
+    CPPUNIT_ASSERT(outAdded == nullptr);
+    CPPUNIT_ASSERT(outCommon == nullptr);
+    CPPUNIT_ASSERT(outRemoved == nullptr);
+
+    outAdded = CFDictionaryCreateMutable(kCFAllocatorDefault,
+                                         0,
+                                         &kCFTypeDictionaryKeyCallBacks,
+                                         &kCFTypeDictionaryValueCallBacks);
+    CPPUNIT_ASSERT(outAdded != nullptr);
+
+    outCommon = CFDictionaryCreateMutable(kCFAllocatorDefault,
+                                          0,
+                                          &kCFTypeDictionaryKeyCallBacks,
+                                          &kCFTypeDictionaryValueCallBacks);
+    CPPUNIT_ASSERT(outCommon != nullptr);
+
+    outRemoved = CFDictionaryCreateMutable(kCFAllocatorDefault,
+                                           0,
+                                           &kCFTypeDictionaryKeyCallBacks,
+                                           &kCFTypeDictionaryValueCallBacks);
+    CPPUNIT_ASSERT(outRemoved != nullptr);
+}
+
+void
+TestCFUDictionaryDifference :: TestDictionaryKeysAndValues(CFDictionaryRef inDictionary,
+                                                           const void **inExpectedFirstKey,
+                                                           const void **inExpectedFirstValue,
+                                                           const size_t &inExpectedCount)
+{
+    CFIndex lDictionaryCount;
+    
+    CPPUNIT_ASSERT(inDictionary != nullptr);
+
+    lDictionaryCount = CFDictionaryGetCount(inDictionary);
+    CPPUNIT_ASSERT(static_cast<size_t>(lDictionaryCount) == inExpectedCount);
+
+    for (size_t i = 0; i < inExpectedCount; i++)
+    {
+        CFStringRef            lStringValue;
+        CFComparisonResult     lComparisonResult;
+
+        lStringValue = reinterpret_cast<CFStringRef>(
+            CFDictionaryGetValue(inDictionary, inExpectedFirstKey[i]));
+        CPPUNIT_ASSERT(lStringValue != NULL);
+
+        lComparisonResult =
+            CFStringCompare(lStringValue,
+                            reinterpret_cast<CFStringRef>(inExpectedFirstValue[i]),
+                            0);
+        CPPUNIT_ASSERT(lComparisonResult == kCFCompareEqualTo);
+    }
+}
+
+void
+TestCFUDictionaryDifference :: TestTeardown(CFMutableDictionaryRef inAdded,
+                                            CFMutableDictionaryRef inCommon,
+                                            CFMutableDictionaryRef inRemoved)
+{
+    CPPUNIT_ASSERT(inAdded != nullptr);
+    CPPUNIT_ASSERT(inCommon != nullptr);
+    CPPUNIT_ASSERT(inRemoved != nullptr);
+
+    CFRelease(inAdded);
+    CFRelease(inCommon);
+    CFRelease(inRemoved);
 }

--- a/tests/TestCFUDictionaryDifference.cpp
+++ b/tests/TestCFUDictionaryDifference.cpp
@@ -1,0 +1,101 @@
+/*
+ *    Copyright (c) 2023 Nuovation System Designs, LLC
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements a unit test for CFUDictionaryDifference.
+ */
+
+#include <CFUtilities/CFUtilities.hpp>
+
+#include <cppunit/TestAssert.h>
+#include <cppunit/extensions/HelperMacros.h>
+
+
+class TestCFUDictionaryDifference :
+    public CppUnit::TestFixture
+{
+    CPPUNIT_TEST_SUITE(TestCFUDictionaryDifference);
+    CPPUNIT_TEST(TestNull);
+    CPPUNIT_TEST_SUITE_END();
+
+public:
+    void TestNull(void);
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION(TestCFUDictionaryDifference);
+
+void
+TestCFUDictionaryDifference :: TestNull(void)
+{
+    CFDictionaryRef        lProposedDictionaryRef = nullptr;
+    CFMutableDictionaryRef lBaseDictionaryRef     = nullptr;
+    CFMutableDictionaryRef lAddedDictionaryRef    = nullptr;
+    CFMutableDictionaryRef lCommonDictionaryRef   = nullptr;
+    CFMutableDictionaryRef lRemovedDictionaryRef  = nullptr;   
+    Boolean                lStatus;
+
+    // Allocate the added, common, and removed dictionaries
+
+    lAddedDictionaryRef = CFDictionaryCreateMutable(kCFAllocatorDefault,
+                                                    0,
+                                                    &kCFTypeDictionaryKeyCallBacks,
+                                                    &kCFTypeDictionaryValueCallBacks);
+    CPPUNIT_ASSERT(lAddedDictionaryRef != NULL);
+
+    lCommonDictionaryRef = CFDictionaryCreateMutable(kCFAllocatorDefault,
+                                                     0,
+                                                     &kCFTypeDictionaryKeyCallBacks,
+                                                     &kCFTypeDictionaryValueCallBacks);
+    CPPUNIT_ASSERT(lCommonDictionaryRef != NULL);
+
+    lRemovedDictionaryRef = CFDictionaryCreateMutable(kCFAllocatorDefault,
+                                                      0,
+                                                      &kCFTypeDictionaryKeyCallBacks,
+                                                      &kCFTypeDictionaryValueCallBacks);
+    CPPUNIT_ASSERT(lRemovedDictionaryRef != NULL);
+
+    // Test the C binding.
+
+    lStatus = CFUDictionaryDifference(lProposedDictionaryRef,
+                                      nullptr,
+                                      lAddedDictionaryRef,
+                                      lCommonDictionaryRef,
+                                      lRemovedDictionaryRef);
+    CPPUNIT_ASSERT(lStatus == false);
+
+    // Test the C++ binding.
+
+    lStatus = CFUDictionaryDifference(lProposedDictionaryRef,
+                                      lBaseDictionaryRef,
+                                      lAddedDictionaryRef,
+                                      lCommonDictionaryRef,
+                                      lRemovedDictionaryRef);
+    CPPUNIT_ASSERT(lStatus == false);
+
+    if (lAddedDictionaryRef != NULL) {
+        CFRelease(lAddedDictionaryRef);
+    }
+
+    if (lCommonDictionaryRef != NULL) {
+        CFRelease(lCommonDictionaryRef);
+    }
+
+    if (lRemovedDictionaryRef != NULL) {
+        CFRelease(lRemovedDictionaryRef);
+    }
+}


### PR DESCRIPTION
This adds C/C++ bindings for `CFUDictionaryDifference` which attempts to apply a difference between the proposed and base dictionaries, returning, if requested by virtue of non-null mutable dictionary references, the entries between the proposed and base dictionaries that are:

1. Unique to the proposed (that is, added relative to the base)
2. Unique to the proposed (that is, removed relative to the base)
3. Common between them, though with potentially different values between the base and proposed in such case, the common dictionary will contain the base value.
