### PR TITLE
Add C/C++ Bindings for 'CFUDictionaryMerge{,WithDifferences,WithDifferencesAndRemovedKeys}'

### DIFF
--- a/include/CFUtilities/CFUtilities.h
+++ b/include/CFUtilities/CFUtilities.h
@@ -52,7 +52,7 @@ extern CFDateRef       CFUDateCreate(CFAllocatorRef inAllocator, time_t inTime);
 // CFDictionary Operations
 
 extern CFArrayRef      CFUDictionaryCopyKeys(CFDictionaryRef inDictionary);
-extern void            CFUDictionaryMerge(CFMutableDictionaryRef inDestination,
+extern Boolean         CFUDictionaryMerge(CFMutableDictionaryRef inDestination,
                                           CFDictionaryRef        inSource,
                                           bool                   inReplace);
 extern Boolean         CFUDictionarySetCString(CFMutableDictionaryRef inDestination,

--- a/include/CFUtilities/CFUtilities.h
+++ b/include/CFUtilities/CFUtilities.h
@@ -55,6 +55,14 @@ extern CFArrayRef      CFUDictionaryCopyKeys(CFDictionaryRef inDictionary);
 extern Boolean         CFUDictionaryMerge(CFMutableDictionaryRef inDestination,
                                           CFDictionaryRef        inSource,
                                           bool                   inReplace);
+extern Boolean         CFUDictionaryMergeWithDifferences(CFMutableDictionaryRef inOutBase,
+                                                         CFDictionaryRef        inAdded,
+                                                         CFDictionaryRef        inCommon,
+                                                         CFDictionaryRef        inRemoved);
+extern Boolean         CFUDictionaryMergeWithDifferencesAndRemovedKeys(CFMutableDictionaryRef inOutBase,
+                                                                       CFDictionaryRef        inAdded,
+                                                                       CFDictionaryRef        inCommon,
+                                                                       CFArrayRef             inRemovedKeys);
 extern Boolean         CFUDictionarySetCString(CFMutableDictionaryRef inDestination,
                                                const void *           inKey,
                                                const char *           inString);

--- a/include/CFUtilities/CFUtilities.hpp
+++ b/include/CFUtilities/CFUtilities.hpp
@@ -311,6 +311,14 @@ extern Boolean CFUDictionaryGetBoolean(CFDictionaryRef inDictionary,
 extern Boolean CFUDictionarySetBoolean(CFMutableDictionaryRef inDictionary,
                                        const void *           inKey,
                                        Boolean                inValue);
+extern Boolean CFUDictionaryMerge(CFMutableDictionaryRef inOutBase,
+                                  CFDictionaryRef        inAdded,
+                                  CFDictionaryRef        inCommon,
+                                  CFDictionaryRef        inRemoved);
+extern Boolean CFUDictionaryMerge(CFMutableDictionaryRef inOutBase,
+                                  CFDictionaryRef        inAdded,
+                                  CFDictionaryRef        inCommon,
+                                  CFArrayRef             inRemovedKeys);
 extern Boolean CFUDictionaryDifference(CFDictionaryRef          inProposed,
                                        CFMutableDictionaryRef & inOutBase,
                                        CFMutableDictionaryRef   outAdded,

--- a/src/CFUtilities.cpp
+++ b/src/CFUtilities.cpp
@@ -415,23 +415,28 @@ done:
  *                                 values already exist in the
  *                                 destination.
  *
+ *  @returns
+ *    True if the merge was successful; otherwise, false. False
+ *    may be returned if an incorrect argument was supplied.
+ *
  *  @ingroup dictionary
  *
  */
-void
+Boolean
 CFUDictionaryMerge(CFMutableDictionaryRef inDestination,
                    CFDictionaryRef        inSource,
                    bool                   inReplace)
 {
     CFUDictionaryMergeContext theContext = { inDestination, inReplace };
+    Boolean                   status     = true;
 
-    __Require(inDestination != nullptr, done);
-    __Require(inSource != nullptr, done);
+    __Require_Action(inDestination != nullptr, done, status = false);
+    __Require_Action(inSource      != nullptr, done, status = false);
 
     CFDictionaryApplyFunction(inSource, CFUDictionaryMergeApplier, &theContext);
 
 done:
-    return;
+    return (status);
 }
 
 /**

--- a/src/CFUtilities.cpp
+++ b/src/CFUtilities.cpp
@@ -68,6 +68,15 @@ enum CFUDictionaryDifferencePhase
 };
 
 /**
+ *  Indicator of the phase of the dictionary merge with differences
+ *  algorithm.
+ *
+ *  @private
+ *
+ */
+typedef CFUDictionaryDifferencePhase CFUDictionaryMergeWithDifferencesPhase;
+
+/**
  *  Iterator context for the dictionary difference interface.
  *
  *  @private
@@ -104,7 +113,7 @@ struct CFUDictionaryDifferenceContext {
 /**
  *  Iterator context for the dictionary merge interface.
  *
- * @private
+ *  @private
  */
 struct CFUDictionaryMergeContext {
     // clang-format off
@@ -120,9 +129,25 @@ struct CFUDictionaryMergeContext {
 };
 
 /**
- * Iterator context used for the set intersection and union interfaces.
+ *  Iterator context for the dictionary merge with differences interfaces.
  *
- * @private
+ *  @private
+ */
+struct CFUDictionaryMergeWithDifferencesContext {
+    // clang-format off
+    CFUDictionaryMergeWithDifferencesPhase  mPhase;                  //!< The current merge
+                                                                     //!< algorithm phase.
+    CFMutableDictionaryRef                  mDestinationDictionary;  //!< A reference to the
+                                                                     //!< mutable dictionary to
+                                                                     //!< merge keys and values
+                                                                     //!< to.
+    // clang-format on
+};
+
+/**
+ *  Iterator context used for the set intersection and union interfaces.
+ *
+ *  @private
  */
 struct CFUSetContext {
     // clang-format off
@@ -364,7 +389,7 @@ CFUDictionaryMergeApplier(const void * inKey,
     CFUDictionaryMergeContext * theContext = nullptr;
     bool                        hasKey;
 
-    __Require(inKey != nullptr, done);
+    __Require(inKey     != nullptr, done);
     __Require(inContext != nullptr, done);
 
     theContext = static_cast<CFUDictionaryMergeContext *>(inContext);
@@ -390,6 +415,346 @@ CFUDictionaryMergeApplier(const void * inKey,
 
 done:
     return;
+}
+
+/**
+ *  This routine is a CoreFoundation dictionary applier function that
+ *  iterates on each key/value pair of an added, common, removed
+ *  difference dictionary (likely generated from
+ *  #CFUDictionaryDifference) and applies the difference to the base
+ *  dictionary as appropriate for the current algorithm phase.
+
+ *
+ *  @param[in]      inKey      A pointer to the key of the current
+ *                             key/value pair being iterated upon.
+ *  @param[in]      inValue    A pointer to the value of the current
+ *                             key/value pair being iterated upon.
+ *  @param[in,out]  inContext  A pointer to the iterator context. On
+ *                             completion and depending on the context
+ *                             phase, the add phase will add those
+ *                             key/value pairs to the base; the remove
+ *                             phase will remove those key/value pairs
+ *                             from the base; and the phase will
+ *                             replace those key/value pairs for which
+ *                             the value is different in the common
+ *                             relative to the base with the value
+ *                             from the common.
+ *
+ *  @private
+ *
+ */
+static void
+CFUDictionaryMergeWithDifferencesApplier(const void * inKey,
+                                         const void * inValue,
+                                         void *       inContext)
+{
+    CFStringRef                                 theKey     =
+        static_cast<CFStringRef>(inKey);
+    CFTypeRef                                   theValue   =
+        static_cast<CFTypeRef>(inValue);
+    CFUDictionaryMergeWithDifferencesContext *  theContext =
+        static_cast<CFUDictionaryMergeWithDifferencesContext *>(inContext);
+
+    __Require(theKey     != nullptr, done);
+    __Require(theValue   != nullptr, done);
+    __Require(theContext != nullptr, done);
+
+    // If the phase is add, set the key/value pair.
+    //
+    // If the phase is common, replace the key/value pair if unequal.
+    //
+    // If the phase is remove, remove the key/value pair.
+
+    if (theContext->mPhase == kCFUDictionaryDifferencePhaseAdd)
+    {
+        CFDictionarySetValue(theContext->mDestinationDictionary, theKey, theValue);
+    }
+    else if (theContext->mPhase == kCFUDictionaryDifferencePhaseCommon)
+    {
+        CFTypeRef      theCurrentValue;
+        Boolean        lEqual;
+
+        theCurrentValue = static_cast<CFTypeRef>(CFDictionaryGetValue(theContext->mDestinationDictionary, theKey));
+        __Require(theCurrentValue != nullptr, done);
+
+        lEqual = CFEqual(theCurrentValue, theValue);
+
+        if (!lEqual)
+        {
+            CFDictionaryReplaceValue(theContext->mDestinationDictionary, theKey, theValue);
+        }
+    }
+    else if (theContext->mPhase == kCFUDictionaryDifferencePhaseRemove)
+    {
+        CFDictionaryRemoveValue(theContext->mDestinationDictionary, theKey);
+    }
+
+ done:
+    return;
+}
+
+/**
+ *  This routine is a CoreFoundation array applier function that
+ *  iterates on each value of a removed keys array and applies them
+ *  difference to the base dictionary, as appropriate for the current
+ *  algorithm phase, by removing the corresponding key/value pairs
+ *  from the base dictionary.
+ *
+ *  @param[in]      inValue    A pointer to the current value being
+ *                             iterated upon. This value is actually a
+ *                             dictionary key.
+ *  @param[in,out]  inContext  A pointer to the iterator context. On
+ *                             completion and depending on the context
+ *                             phase, the remove phase will remove
+ *                             those key/value pairs from the base.
+ *
+ *  @private
+ *
+ */
+static void
+CFUDictionaryMergeWithDifferencesApplierAndRemovedKeysApplier(const void * inValue,
+                                                              void *       inContext)
+{
+    // Note that that since this actually matches the signature of an
+    // array applier, in this context, the array values are actually
+    // dictionary keys. Consequently, the local is named accordingly.
+
+    CFDictionaryRef                             theKey     =
+        static_cast<CFDictionaryRef>(inValue);
+    CFUDictionaryMergeWithDifferencesContext *  theContext =
+        static_cast<CFUDictionaryMergeWithDifferencesContext *>(inContext);
+
+    __Require(theKey     != nullptr, done);
+    __Require(theContext != nullptr, done);
+
+    // There is only work to do in this case for the removal
+    // phase. Other phases are handled with other applier functions.
+
+    if (theContext->mPhase == kCFUDictionaryDifferencePhaseRemove)
+    {
+        CFDictionaryRemoveValue(theContext->mDestinationDictionary, theKey);
+    }
+
+ done:
+    return;
+}
+
+/**
+ *  @brief
+ *    Merge a CoreFoundation dictionary from one or more difference
+ *    dictionaries.
+ *
+ *  This routine merges a mutable CoreFoundation dictionary from one
+ *  or more difference dictionaries (likely generated from
+ *  #CFUDictionaryDifference). If present, key/value pairs in the @a
+ *  inAdded dictionary are added to @a inOutBase and, if present,
+ *  key/value pairs in the @a inCommon dictionary replace those in @a
+ *  inOutBase if the values are different.
+ *
+ *  @param[in,out]  inOutBase  A reference to the mutable dictionary
+ *                             to merge keys and values to. On
+ *                             success, @a inOutBase contains a
+ *                             reference to the destination dictionary
+ *                             with entries from the added and common
+ *                             dictionaries merged in.
+ *  @param[out]     inAdded    An optional reference to the dictionary
+ *                             containing entries to be added to the
+ *                             base dictionary. If null, no such
+ *                             entries will be added.
+ *  @param[in]      inCommon   An optional reference to the dictionary
+ *                             containing entries common to the base
+ *                             dictionary, but potentially with
+ *                             different values. Values that are
+ *                             different will replace those in the
+ *                             base. If null, no such entries will be
+ *                             replaced.
+ *
+ *  @private
+ *
+ */
+static void
+CFUDictionaryMerge(CFUDictionaryMergeWithDifferencesContext &  inOutContext,
+                   CFMutableDictionaryRef                      inOutBase,
+                   CFDictionaryRef                             inAdded,
+                   CFDictionaryRef                             inCommon)
+{
+    inOutContext.mDestinationDictionary = inOutBase;
+
+    if (inAdded != nullptr)
+    {
+        // Add new values
+
+        inOutContext.mPhase = kCFUDictionaryDifferencePhaseAdd;
+
+        CFDictionaryApplyFunction(inAdded,
+                                  CFUDictionaryMergeWithDifferencesApplier,
+                                  &inOutContext);
+    }
+
+    if (inCommon != nullptr)
+    {
+        // Update common values;
+
+        inOutContext.mPhase = kCFUDictionaryDifferencePhaseCommon;
+
+        CFDictionaryApplyFunction(inCommon,
+                                  CFUDictionaryMergeWithDifferencesApplier,
+                                  &inOutContext);
+    }
+}
+
+/**
+ *  @brief
+ *    Merge a CoreFoundation dictionary from one or more difference
+ *    dictionaries.
+ *
+ *  This routine merges a mutable CoreFoundation dictionary from one
+ *  or more difference dictionaries (likely generated from
+ *  #CFUDictionaryDifference). If present, key/value pairs in the @a
+ *  inAdded dictionary are added to @a inOutBase; if present,
+ *  key/value pairs in the @a inCommon dictionary replace those in @a
+ *  inOutBase if the values are different; and, if present, key/value
+ *  pairs in the @a inRemoved dictionary are removed from @a
+ *  inOutBase.
+ *
+ *  @param[in,out]  inOutBase  A reference to the mutable dictionary
+ *                             to merge keys and values to. On
+ *                             success, @a inOutBase contains
+ *                             a reference to the destination
+ *                             dictionary with entries from the
+ *                             added, common, and removed
+ *                             dictionaries merged in.
+ *  @param[out]     inAdded    An optional reference to the dictionary
+ *                             containing entries to be added to the
+ *                             base dictionary. If null, no such
+ *                             entries will be added.
+ *  @param[in]      inCommon   An optional reference to the dictionary
+ *                             containing entries common to the base
+ *                             dictionary, but potentially with
+ *                             different values. Values that are
+ *                             different will replace those in the
+ *                             base. If null, no such entries will be
+ *                             replaced.
+ *  @param[in]      inRemoved  An optional reference to the dictionary
+ *                             containing entries to be removed from
+ *                             the base dictionary. If null, no such
+ *                             entries will be removed.
+ *
+ *  @returns
+ *    True if the merge was successful; otherwise, false. False
+ *    may be returned if an incorrect argument was supplied.
+ *
+ *  @sa CFUDictionaryDifference
+ *
+ *  @ingroup dictionary
+ *
+ */
+Boolean
+CFUDictionaryMerge(CFMutableDictionaryRef inOutBase,
+                   CFDictionaryRef        inAdded,
+                   CFDictionaryRef        inCommon,
+                   CFDictionaryRef        inRemoved)
+{
+    CFUDictionaryMergeWithDifferencesContext  theContext;
+    Boolean                                   status = true;
+
+    __Require_Action(inOutBase != nullptr, done, status = false);
+
+    // Add new and update common values
+
+    CFUDictionaryMerge(theContext, inOutBase, inAdded, inCommon);
+
+    if (inRemoved != nullptr)
+    {
+        // Remove old values
+
+        theContext.mPhase = kCFUDictionaryDifferencePhaseRemove;
+
+        CFDictionaryApplyFunction(inRemoved,
+                                  CFUDictionaryMergeWithDifferencesApplier,
+                                  &theContext);
+    }
+
+ done:
+    return (status);
+}
+
+/**
+ *  @brief
+ *    Merge a CoreFoundation dictionary from one or more difference
+ *    dictionaries.
+ *
+ *  This routine merges a mutable CoreFoundation dictionary from two
+ *  or more difference dictionaries (likely generated from
+ *  #CFUDictionaryDifference) and a difference array, containing
+ *  removed keys. If present, key/value pairs in the @a inAdded
+ *  dictionary are added to @a inOutBase; if present, key/value pairs
+ *  in the @a inCommon dictionary replace those in @a inOutBase if the
+ *  values are different; and, if present, keys in the @a
+ *  inRemovedKeys array are removed from @a inOutBase.
+ *
+ *  @param[in,out]  inOutBase      A reference to the mutable
+ *                                 dictionary to merge keys and values
+ *                                 to. On success, @a inOutBase
+ *                                 contains a reference to the
+ *                                 destination dictionary with entries
+ *                                 from the added and common
+ *                                 dictionaries and the removed keys
+ *                                 array merged in.
+ *  @param[out]     inAdded        An optional reference to the
+ *                                 dictionary containing entries to be
+ *                                 added to the base dictionary. If
+ *                                 null, no such entries will be
+ *                                 added.
+ *  @param[in]      inCommon       An optional reference to the
+ *                                 dictionary containing entries
+ *                                 common to the base dictionary, but
+ *                                 potentially with different
+ *                                 values. Values that are different
+ *                                 will replace those in the base. If
+ *                                 null, no such entries will be
+ *                                 replaced.
+ *  @param[in]      inRemovedKeys  An optional reference to the array
+ *                                 containing key to be removed from
+ *                                 the base dictionary. If null, no such
+ *                                 entries will be removed.
+ *
+ *  @returns
+ *    True if the merge was successful; otherwise, false. False
+ *    may be returned if an incorrect argument was supplied.
+ *
+ *  @ingroup dictionary
+ *
+ */
+Boolean
+CFUDictionaryMerge(CFMutableDictionaryRef inOutBase,
+                   CFDictionaryRef        inAdded,
+                   CFDictionaryRef        inCommon,
+                   CFArrayRef             inRemovedKeys)
+{
+    CFUDictionaryMergeWithDifferencesContext  theContext;
+    Boolean                                   status = true;
+
+    __Require_Action(inOutBase != nullptr, done, status = false);
+
+    // Add new and update common values
+
+    CFUDictionaryMerge(theContext, inOutBase, inAdded, inCommon);
+
+    if (inRemovedKeys != nullptr)
+    {
+        // Remove old values
+
+        theContext.mPhase = kCFUDictionaryDifferencePhaseRemove;
+
+        CFArrayApplyFunction(inRemovedKeys,
+                             CFRangeMake(0, CFArrayGetCount(inRemovedKeys)),
+                             CFUDictionaryMergeWithDifferencesApplierAndRemovedKeysApplier,
+                             &theContext);
+    }
+
+ done:
+    return (status);
 }
 
 /**
@@ -436,6 +801,129 @@ CFUDictionaryMerge(CFMutableDictionaryRef inDestination,
     CFDictionaryApplyFunction(inSource, CFUDictionaryMergeApplier, &theContext);
 
 done:
+    return (status);
+}
+
+/**
+ *  @brief
+ *    Merge a CoreFoundation dictionary from one or more difference
+ *    dictionaries.
+ *
+ *  This routine merges a mutable CoreFoundation dictionary from one
+ *  or more difference dictionaries (likely generated from
+ *  #CFUDictionaryDifference). If present, key/value pairs in the @a
+ *  inAdded dictionary are added to @a inOutBase; if present,
+ *  key/value pairs in the @a inCommon dictionary replace those in @a
+ *  inOutBase if the values are different; and, if present, key/value
+ *  pairs in the @a inRemoved dictionary are removed from @a
+ *  inOutBase.
+ *
+ *  @param[in,out]  inOutBase  A reference to the mutable dictionary
+ *                             to merge keys and values to. On
+ *                             success, @a inOutBase contains
+ *                             a reference to the destination
+ *                             dictionary with entries from the
+ *                             added, common, and removed
+ *                             dictionaries merged in.
+ *  @param[out]     inAdded    An optional reference to the dictionary
+ *                             containing entries to be added to the
+ *                             base dictionary. If null, no such
+ *                             entries will be added.
+ *  @param[in]      inCommon   An optional reference to the dictionary
+ *                             containing entries common to the base
+ *                             dictionary, but potentially with
+ *                             different values. Values that are
+ *                             different will replace those in the
+ *                             base. If null, no such entries will be
+ *                             replaced.
+ *  @param[in]      inRemoved  An optional reference to the dictionary
+ *                             containing entries to be removed from
+ *                             the base dictionary. If null, no such
+ *                             entries will be removed.
+ *
+ *  @returns
+ *    True if the merge was successful; otherwise, false. False
+ *    may be returned if an incorrect argument was supplied.
+ *
+ *  @ingroup dictionary
+ *
+ */
+Boolean
+CFUDictionaryMergeWithDifferences(CFMutableDictionaryRef inOutBase,
+                                  CFDictionaryRef        inAdded,
+                                  CFDictionaryRef        inCommon,
+                                  CFDictionaryRef        inRemoved)
+{
+    Boolean status = true;
+
+    status = CFUDictionaryMerge(inOutBase,
+                                inAdded,
+                                inCommon,
+                                inRemoved);
+
+    return (status);
+}
+
+/**
+ *  @brief
+ *    Merge a CoreFoundation dictionary from one or more difference
+ *    dictionaries.
+ *
+ *  This routine merges a mutable CoreFoundation dictionary from two
+ *  or more difference dictionaries (likely generated from
+ *  #CFUDictionaryDifference) and a difference array, containing
+ *  removed keys. If present, key/value pairs in the @a inAdded
+ *  dictionary are added to @a inOutBase; if present, key/value pairs
+ *  in the @a inCommon dictionary replace those in @a inOutBase if the
+ *  values are different; and, if present, keys in the @a
+ *  inRemovedKeys array are removed from @a inOutBase.
+ *
+ *  @param[in,out]  inOutBase      A reference to the mutable
+ *                                 dictionary to merge keys and values
+ *                                 to. On success, @a inOutBase
+ *                                 contains a reference to the
+ *                                 destination dictionary with entries
+ *                                 from the added and common
+ *                                 dictionaries and the removed keys
+ *                                 array merged in.
+ *  @param[out]     inAdded        An optional reference to the
+ *                                 dictionary containing entries to be
+ *                                 added to the base dictionary. If
+ *                                 null, no such entries will be
+ *                                 added.
+ *  @param[in]      inCommon       An optional reference to the
+ *                                 dictionary containing entries
+ *                                 common to the base dictionary, but
+ *                                 potentially with different
+ *                                 values. Values that are different
+ *                                 will replace those in the base. If
+ *                                 null, no such entries will be
+ *                                 replaced.
+ *  @param[in]      inRemovedKeys  An optional reference to the array
+ *                                 containing key to be removed from
+ *                                 the base dictionary. If null, no such
+ *                                 entries will be removed.
+ *
+ *  @returns
+ *    True if the merge was successful; otherwise, false. False
+ *    may be returned if an incorrect argument was supplied.
+ *
+ *  @ingroup dictionary
+ *
+ */
+Boolean
+CFUDictionaryMergeWithDifferencesAndRemovedKeys(CFMutableDictionaryRef inOutBase,
+                                                CFDictionaryRef        inAdded,
+                                                CFDictionaryRef        inCommon,
+                                                CFArrayRef             inRemovedKeys)
+{
+    Boolean status = true;
+
+    status = CFUDictionaryMerge(inOutBase,
+                                inAdded,
+                                inCommon,
+                                inRemovedKeys);
+
     return (status);
 }
 
@@ -849,6 +1337,8 @@ CFUDictionaryDifferenceContextSetup(CFDictionaryRef inProposed,
  *    may be returned if an incorrect argument was supplied or if
  *    memory allocation was unsuccessful.
  *
+ *  @ingroup dictionary
+ *
  */
 Boolean
 CFUDictionaryDifference(CFDictionaryRef inProposed,
@@ -940,6 +1430,8 @@ CFUDictionaryDifference(CFDictionaryRef inProposed,
  *    True if the difference was successful; otherwise, false. False
  *    may be returned if an incorrect argument was supplied or if
  *    memory allocation was unsuccessful.
+ *
+ *  @ingroup dictionary
  *
  */
 Boolean

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -27,184 +27,189 @@ include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
 # Local headers to build against and distribute but not to install
 # since they are not part of the package.
 #
-noinst_HEADERS                                 = \
+noinst_HEADERS                                = \
     $(NULL)
 
 #
 # Other files we do want to distribute with the package.
 #
-EXTRA_DIST                                     = \
+EXTRA_DIST                                    = \
     $(NULL)
 
 if CFUTILITIES_BUILD_TESTS
 # C preprocessor option flags that will apply to all compiled objects in this
 # makefile.
 
-AM_CPPFLAGS                                    = \
-    -I$(top_srcdir)/include                      \
-    $(CPPUNIT_CPPFLAGS)                          \
+AM_CPPFLAGS                                   = \
+    -I$(top_srcdir)/include                     \
+    $(CPPUNIT_CPPFLAGS)                         \
     $(NULL)
 
-COMMON_LDADD                                   = \
-    $(top_builddir)/src/libCFUtilities.la        \
-    $(CPPUNIT_LDFLAGS) $(CPPUNIT_LIBS)           \
+COMMON_LDADD                                  = \
+    $(top_builddir)/src/libCFUtilities.la       \
+    $(CPPUNIT_LDFLAGS) $(CPPUNIT_LIBS)          \
     $(NULL)
 
 # Test applications that should be run when the 'check' target is run.
 
-check_PROGRAMS                          = \
-    TestCFMutableString                   \
-    TestCFString                          \
-    TestCFUAbsoluteTimeGetPOSIXTime       \
-    TestCFUBooleanCreate                  \
-    TestCFUDateCreate                     \
-    TestCFUDateGetPOSIXTime               \
-    TestCFUDictionaryCopyKeys             \
-    TestCFUDictionaryDifference           \
-    TestCFUDictionaryMerge                \
-    TestCFUDictionaryGetBoolean           \
-    TestCFUDictionarySetBoolean           \
-    TestCFUDictionarySetCString           \
-    TestCFUGetNumberType                  \
-    TestCFUIsTypeID                       \
-    TestCFUPOSIXTimeGetAbsoluteTime       \
-    TestCFUPropertyListRead               \
-    TestCFUPropertyListWrite              \
-    TestCFUReferenceSet                   \
-    TestCFURelease                        \
-    TestCFUSetIsEmptySet                  \
-    TestCFUSetIntersectionSet             \
-    TestCFUSetUnionSet                    \
-    TestCFUStringsMatch                   \
-    TestCFUTreeContextInit                \
-    TestCFUTreeCreate                     \
+check_PROGRAMS                                = \
+    TestCFMutableString                         \
+    TestCFString                                \
+    TestCFUAbsoluteTimeGetPOSIXTime             \
+    TestCFUBooleanCreate                        \
+    TestCFUDateCreate                           \
+    TestCFUDateGetPOSIXTime                     \
+    TestCFUDictionaryCopyKeys                   \
+    TestCFUDictionaryDifference                 \
+    TestCFUDictionaryMerge                      \
+    TestCFUDictionaryMergeWithDifferences       \
+    TestCFUDictionaryGetBoolean                 \
+    TestCFUDictionarySetBoolean                 \
+    TestCFUDictionarySetCString                 \
+    TestCFUGetNumberType                        \
+    TestCFUIsTypeID                             \
+    TestCFUPOSIXTimeGetAbsoluteTime             \
+    TestCFUPropertyListRead                     \
+    TestCFUPropertyListWrite                    \
+    TestCFUReferenceSet                         \
+    TestCFURelease                              \
+    TestCFUSetIsEmptySet                        \
+    TestCFUSetIntersectionSet                   \
+    TestCFUSetUnionSet                          \
+    TestCFUStringsMatch                         \
+    TestCFUTreeContextInit                      \
+    TestCFUTreeCreate                           \
     $(NULL)
 
 # Test applications and scripts that should be built and run when the
 # 'check' target is run.
 
-TESTS                                   = \
-    $(check_PROGRAMS)                     \
+TESTS                                         = \
+    $(check_PROGRAMS)                           \
     $(NULL)
 
 # The additional environment variables and their values that will be
 # made available to all programs and scripts in TESTS.
 
-TESTS_ENVIRONMENT                       = \
+TESTS_ENVIRONMENT                             = \
     $(NULL)
 
 # Source, compiler, and linker options for test programs.
 
-TestCFMutableString_LDADD               = $(COMMON_LDADD)
-TestCFMutableString_SOURCES             = TestDriver.cpp                      \
-                                          TestCFMutableString.cpp
+TestCFMutableString_LDADD                     = $(COMMON_LDADD)
+TestCFMutableString_SOURCES                   = TestDriver.cpp                      \
+                                                TestCFMutableString.cpp
 
-TestCFString_LDADD                      = $(COMMON_LDADD)
-TestCFString_SOURCES                    = TestDriver.cpp                      \
-                                          TestCFString.cpp
+TestCFString_LDADD                            = $(COMMON_LDADD)
+TestCFString_SOURCES                          = TestDriver.cpp                      \
+                                                TestCFString.cpp
 
-TestCFUAbsoluteTimeGetPOSIXTime_LDADD   = $(COMMON_LDADD)
-TestCFUAbsoluteTimeGetPOSIXTime_SOURCES = TestDriver.cpp                      \
-                                          TestCFUAbsoluteTimeGetPOSIXTime.cpp
+TestCFUAbsoluteTimeGetPOSIXTime_LDADD         = $(COMMON_LDADD)
+TestCFUAbsoluteTimeGetPOSIXTime_SOURCES       = TestDriver.cpp                      \
+                                                TestCFUAbsoluteTimeGetPOSIXTime.cpp
 
-TestCFUBooleanCreate_LDADD              = $(COMMON_LDADD)
-TestCFUBooleanCreate_SOURCES            = TestDriver.cpp                      \
-                                          TestCFUBooleanCreate.cpp
+TestCFUBooleanCreate_LDADD                    = $(COMMON_LDADD)
+TestCFUBooleanCreate_SOURCES                  = TestDriver.cpp                      \
+                                                TestCFUBooleanCreate.cpp
 
-TestCFUDateCreate_LDADD                 = $(COMMON_LDADD)
-TestCFUDateCreate_SOURCES               = TestDriver.cpp                      \
-                                          TestCFUDateCreate.cpp
+TestCFUDateCreate_LDADD                       = $(COMMON_LDADD)
+TestCFUDateCreate_SOURCES                     = TestDriver.cpp                      \
+                                                TestCFUDateCreate.cpp
 
-TestCFUDictionaryCopyKeys_LDADD         = $(COMMON_LDADD)
-TestCFUDictionaryCopyKeys_SOURCES       = TestDriver.cpp                      \
-                                          TestCFUDictionaryCopyKeys.cpp
+TestCFUDictionaryCopyKeys_LDADD               = $(COMMON_LDADD)
+TestCFUDictionaryCopyKeys_SOURCES             = TestDriver.cpp                      \
+                                                TestCFUDictionaryCopyKeys.cpp
 
-TestCFUDictionaryDifference_LDADD       = $(COMMON_LDADD)
-TestCFUDictionaryDifference_SOURCES     = TestDriver.cpp                      \
-                                          TestCFUDictionaryDifference.cpp
+TestCFUDictionaryDifference_LDADD             = $(COMMON_LDADD)
+TestCFUDictionaryDifference_SOURCES           = TestDriver.cpp                      \
+                                                TestCFUDictionaryDifference.cpp
 
-TestCFUDictionaryMerge_LDADD            = $(COMMON_LDADD)
-TestCFUDictionaryMerge_SOURCES          = TestDriver.cpp                      \
-                                          TestCFUDictionaryMerge.cpp
+TestCFUDictionaryMerge_LDADD                  = $(COMMON_LDADD)
+TestCFUDictionaryMerge_SOURCES                = TestDriver.cpp                      \
+                                                TestCFUDictionaryMerge.cpp
 
-TestCFUDictionaryGetBoolean_LDADD       = $(COMMON_LDADD)
-TestCFUDictionaryGetBoolean_SOURCES     = TestDriver.cpp                      \
-                                          TestCFUDictionaryGetBoolean.cpp
+TestCFUDictionaryMergeWithDifferences_LDADD   = $(COMMON_LDADD)
+TestCFUDictionaryMergeWithDifferences_SOURCES = TestDriver.cpp                      \
+                                                TestCFUDictionaryMergeWithDifferences.cpp
 
-TestCFUDictionarySetBoolean_LDADD       = $(COMMON_LDADD)
-TestCFUDictionarySetBoolean_SOURCES     = TestDriver.cpp                      \
-                                          TestCFUDictionarySetBoolean.cpp
+TestCFUDictionaryGetBoolean_LDADD             = $(COMMON_LDADD)
+TestCFUDictionaryGetBoolean_SOURCES           = TestDriver.cpp                      \
+                                                TestCFUDictionaryGetBoolean.cpp
 
-TestCFUDictionarySetCString_LDADD       = $(COMMON_LDADD)
-TestCFUDictionarySetCString_SOURCES     = TestDriver.cpp                      \
-                                          TestCFUDictionarySetCString.cpp
+TestCFUDictionarySetBoolean_LDADD             = $(COMMON_LDADD)
+TestCFUDictionarySetBoolean_SOURCES           = TestDriver.cpp                      \
+                                                TestCFUDictionarySetBoolean.cpp
 
-TestCFUDateGetPOSIXTime_LDADD           = $(COMMON_LDADD)
-TestCFUDateGetPOSIXTime_SOURCES         = TestDriver.cpp                      \
-                                          TestCFUDateGetPOSIXTime.cpp
+TestCFUDictionarySetCString_LDADD             = $(COMMON_LDADD)
+TestCFUDictionarySetCString_SOURCES           = TestDriver.cpp                      \
+                                                TestCFUDictionarySetCString.cpp
 
-TestCFUGetNumberType_LDADD              = $(COMMON_LDADD)
-TestCFUGetNumberType_SOURCES            = TestDriver.cpp                      \
-                                          TestCFUGetNumberType.cpp
+TestCFUDateGetPOSIXTime_LDADD                 = $(COMMON_LDADD)
+TestCFUDateGetPOSIXTime_SOURCES               = TestDriver.cpp                      \
+                                                TestCFUDateGetPOSIXTime.cpp
 
-TestCFUIsTypeID_LDADD                   = $(COMMON_LDADD)
-TestCFUIsTypeID_SOURCES                 = TestDriver.cpp                      \
-                                          TestCFUIsTypeID.cpp
+TestCFUGetNumberType_LDADD                    = $(COMMON_LDADD)
+TestCFUGetNumberType_SOURCES                  = TestDriver.cpp                      \
+                                                TestCFUGetNumberType.cpp
 
-TestCFUPOSIXTimeGetAbsoluteTime_LDADD   = $(COMMON_LDADD)
-TestCFUPOSIXTimeGetAbsoluteTime_SOURCES = TestDriver.cpp                      \
-                                          TestCFUPOSIXTimeGetAbsoluteTime.cpp
+TestCFUIsTypeID_LDADD                         = $(COMMON_LDADD)
+TestCFUIsTypeID_SOURCES                       = TestDriver.cpp                      \
+                                                TestCFUIsTypeID.cpp
 
-TestCFUPropertyListRead_LDADD           = $(COMMON_LDADD)
-TestCFUPropertyListRead_SOURCES         = TestDriver.cpp                      \
-                                          TestCFUPropertyListRead.cpp
+TestCFUPOSIXTimeGetAbsoluteTime_LDADD         = $(COMMON_LDADD)
+TestCFUPOSIXTimeGetAbsoluteTime_SOURCES       = TestDriver.cpp                      \
+                                                TestCFUPOSIXTimeGetAbsoluteTime.cpp
 
-TestCFUPropertyListWrite_LDADD          = $(COMMON_LDADD)
-TestCFUPropertyListWrite_SOURCES        = TestDriver.cpp                      \
-                                          TestCFUPropertyListWrite.cpp
+TestCFUPropertyListRead_LDADD                 = $(COMMON_LDADD)
+TestCFUPropertyListRead_SOURCES               = TestDriver.cpp                      \
+                                                TestCFUPropertyListRead.cpp
 
-TestCFUReferenceSet_LDADD               = $(COMMON_LDADD)
-TestCFUReferenceSet_SOURCES             = TestDriver.cpp                      \
-                                          TestCFUReferenceSet.cpp
+TestCFUPropertyListWrite_LDADD                = $(COMMON_LDADD)
+TestCFUPropertyListWrite_SOURCES              = TestDriver.cpp                      \
+                                                TestCFUPropertyListWrite.cpp
 
-TestCFURelease_LDADD                    = $(COMMON_LDADD)
-TestCFURelease_SOURCES                  = TestDriver.cpp                      \
-                                          TestCFURelease.cpp
+TestCFUReferenceSet_LDADD                     = $(COMMON_LDADD)
+TestCFUReferenceSet_SOURCES                   = TestDriver.cpp                      \
+                                                TestCFUReferenceSet.cpp
 
-TestCFUSetIntersectionSet_LDADD         = $(COMMON_LDADD)
-TestCFUSetIntersectionSet_SOURCES       = TestDriver.cpp                      \
-                                          TestCFUSetIntersectionSet.cpp
+TestCFURelease_LDADD                          = $(COMMON_LDADD)
+TestCFURelease_SOURCES                        = TestDriver.cpp                      \
+                                                TestCFURelease.cpp
 
-TestCFUSetIsEmptySet_LDADD              = $(COMMON_LDADD)
-TestCFUSetIsEmptySet_SOURCES            = TestDriver.cpp                      \
-                                          TestCFUSetIsEmptySet.cpp
+TestCFUSetIntersectionSet_LDADD               = $(COMMON_LDADD)
+TestCFUSetIntersectionSet_SOURCES             = TestDriver.cpp                      \
+                                                TestCFUSetIntersectionSet.cpp
 
-TestCFUSetUnionSet_LDADD                = $(COMMON_LDADD)
-TestCFUSetUnionSet_SOURCES              = TestDriver.cpp                      \
-                                          TestCFUSetUnionSet.cpp
+TestCFUSetIsEmptySet_LDADD                    = $(COMMON_LDADD)
+TestCFUSetIsEmptySet_SOURCES                  = TestDriver.cpp                      \
+                                                TestCFUSetIsEmptySet.cpp
 
-TestCFUStringsMatch_LDADD               = $(COMMON_LDADD)
-TestCFUStringsMatch_SOURCES             = TestDriver.cpp                      \
-                                          TestCFUStringsMatch.cpp
+TestCFUSetUnionSet_LDADD                      = $(COMMON_LDADD)
+TestCFUSetUnionSet_SOURCES                    = TestDriver.cpp                      \
+                                                TestCFUSetUnionSet.cpp
 
-TestCFUTreeContextInit_LDADD            = $(COMMON_LDADD)
-TestCFUTreeContextInit_SOURCES          = TestDriver.cpp                      \
-                                          TestCFUTreeContextInit.cpp
+TestCFUStringsMatch_LDADD                     = $(COMMON_LDADD)
+TestCFUStringsMatch_SOURCES                   = TestDriver.cpp                      \
+                                                TestCFUStringsMatch.cpp
 
-TestCFUTreeCreate_LDADD                 = $(COMMON_LDADD)
-TestCFUTreeCreate_SOURCES               = TestDriver.cpp                      \
-                                          TestCFUTreeCreate.cpp
+TestCFUTreeContextInit_LDADD                  = $(COMMON_LDADD)
+TestCFUTreeContextInit_SOURCES                = TestDriver.cpp                      \
+                                                TestCFUTreeContextInit.cpp
+
+TestCFUTreeCreate_LDADD                       = $(COMMON_LDADD)
+TestCFUTreeCreate_SOURCES                     = TestDriver.cpp                      \
+                                                TestCFUTreeCreate.cpp
 
 if CFUTILITIES_BUILD_COVERAGE
-CLEANFILES                              = $(wildcard *.gcda *.gcno *.info)
+CLEANFILES                                    = $(wildcard *.gcda *.gcno *.info)
 
 if CFUTILITIES_BUILD_COVERAGE_REPORTS
 # The bundle should positively be qualified with the absolute build
 # path. Otherwise, VPATH will get auto-prefixed to it if there is
 # already such a directory in the non-colocated source tree.
 
-CFUTILITIES_COVERAGE_BUNDLE             = ${abs_builddir}/${PACKAGE}${NL_COVERAGE_BUNDLE_SUFFIX}
-CFUTILITIES_COVERAGE_INFO               = ${CFUTILITIES_COVERAGE_BUNDLE}/${PACKAGE}${NL_COVERAGE_INFO_SUFFIX}
+CFUTILITIES_COVERAGE_BUNDLE                   = ${abs_builddir}/${PACKAGE}${NL_COVERAGE_BUNDLE_SUFFIX}
+CFUTILITIES_COVERAGE_INFO                     = ${CFUTILITIES_COVERAGE_BUNDLE}/${PACKAGE}${NL_COVERAGE_INFO_SUFFIX}
 
 $(CFUTILITIES_COVERAGE_BUNDLE):
 	$(call create-directory)

--- a/tests/TestCFUDictionaryMerge.cpp
+++ b/tests/TestCFUDictionaryMerge.cpp
@@ -57,6 +57,7 @@ TestCFUDictionaryMerge :: TestNull(void)
     const bool             kReplace              = true;
     CFMutableDictionaryRef lMutableDictionaryRef = NULL;
     CFDictionaryRef        lDictionaryRef        = NULL;
+    Boolean                lStatus;
 
     lMutableDictionaryRef = CFDictionaryCreateMutable(kCFAllocatorDefault,
                                                       0,
@@ -74,15 +75,18 @@ TestCFUDictionaryMerge :: TestNull(void)
 
     // Test NULL destination and non-NULL source
 
-    CFUDictionaryMerge(NULL, lDictionaryRef, kReplace);
+    lStatus = CFUDictionaryMerge(NULL, lDictionaryRef, kReplace);
+    CPPUNIT_ASSERT(lStatus == false);
 
     // Test non-NULL destination and NULL source
 
-    CFUDictionaryMerge(lMutableDictionaryRef, NULL, kReplace);
+    lStatus = CFUDictionaryMerge(lMutableDictionaryRef, NULL, kReplace);
+    CPPUNIT_ASSERT(lStatus == false);
 
     // Test NULL destination and source
 
-    CFUDictionaryMerge(NULL, NULL, kReplace);
+    lStatus = CFUDictionaryMerge(NULL, NULL, kReplace);
+    CPPUNIT_ASSERT(lStatus == false);
 
     if (lDictionaryRef != NULL) {
         CFRelease(lDictionaryRef);
@@ -135,6 +139,7 @@ TestCFUDictionaryMerge :: TestNonNullNoIntersection(const bool & aReplace)
     CFIndex                lDictionaryCount;
     CFStringRef            lStringValue;
     CFComparisonResult     lComparisonResult;
+    Boolean                lStatus;
 
     lMutableDictionaryRef = CFDictionaryCreateMutable(kCFAllocatorDefault,
                                                       0,
@@ -160,7 +165,8 @@ TestCFUDictionaryMerge :: TestNonNullNoIntersection(const bool & aReplace)
     // Merge the two dictionaries (source into destination,
     // non-mutable into mutable).
 
-    CFUDictionaryMerge(lMutableDictionaryRef, lDictionaryRef, aReplace);
+    lStatus = CFUDictionaryMerge(lMutableDictionaryRef, lDictionaryRef, aReplace);
+    CPPUNIT_ASSERT(lStatus == true);
     CPPUNIT_ASSERT(lMutableDictionaryRef != NULL);
     CPPUNIT_ASSERT(lDictionaryRef != NULL);
 
@@ -270,6 +276,7 @@ TestCFUDictionaryMerge :: TestNonNullIntersection(const bool & aReplace)
     CFIndex                lDictionaryCount;
     CFStringRef            lStringValue;
     CFComparisonResult     lComparisonResult;
+    Boolean                lStatus;
 
     lMutableDictionaryRef = CFDictionaryCreateMutable(kCFAllocatorDefault,
                                                       0,
@@ -298,7 +305,8 @@ TestCFUDictionaryMerge :: TestNonNullIntersection(const bool & aReplace)
     // Merge the two dictionaries (source into destination,
     // non-mutable into mutable).
 
-    CFUDictionaryMerge(lMutableDictionaryRef, lDictionaryRef, aReplace);
+    lStatus = CFUDictionaryMerge(lMutableDictionaryRef, lDictionaryRef, aReplace);
+    CPPUNIT_ASSERT(lStatus == true);
     CPPUNIT_ASSERT(lMutableDictionaryRef != NULL);
     CPPUNIT_ASSERT(lDictionaryRef != NULL);
 

--- a/tests/TestCFUDictionaryMergeWithDifferences.cpp
+++ b/tests/TestCFUDictionaryMergeWithDifferences.cpp
@@ -1,0 +1,1679 @@
+/*
+ *    Copyright (c) 2023 Nuovation System Designs, LLC
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements a unit test for the C/C++ bindings for
+ *      TestCFUDictionaryMergeWithDifferences.
+ */
+
+#include <CFUtilities/CFUtilities.hpp>
+
+#include <cppunit/TestAssert.h>
+#include <cppunit/extensions/HelperMacros.h>
+
+
+class TestCFUDictionaryMergeWithDifferences :
+    public CppUnit::TestFixture
+{
+    CPPUNIT_TEST_SUITE(TestCFUDictionaryMergeWithDifferences);
+    CPPUNIT_TEST(TestNull);
+    CPPUNIT_TEST(TestBaseWithNoDifferences);
+    CPPUNIT_TEST(TestBaseWithAddedOnly);
+    CPPUNIT_TEST(TestBaseWithCommonOnly);
+    CPPUNIT_TEST(TestBaseWithRemovedOnly);
+    CPPUNIT_TEST(TestBaseWithAddedAndCommonOnly);
+    CPPUNIT_TEST(TestBaseWithAddedAndRemovedOnly);
+    CPPUNIT_TEST(TestBaseWithCommonAndRemovedOnly);
+    CPPUNIT_TEST(TestBaseWithCommonDifferentValues);
+    CPPUNIT_TEST_SUITE_END();
+
+public:
+    void TestNull(void);
+    void TestBaseWithNoDifferences(void);
+    void TestBaseWithAddedOnly(void);
+    void TestBaseWithCommonOnly(void);
+    void TestBaseWithRemovedOnly(void);
+    void TestBaseWithAddedAndCommonOnly(void);
+    void TestBaseWithAddedAndRemovedOnly(void);
+    void TestBaseWithCommonAndRemovedOnly(void);
+    void TestBaseWithCommonSameValues(void);
+    void TestBaseWithCommonDifferentValues(void);
+
+private:
+    void TestDictionaryPopulateWithKeysAndValues(const void **inFirstKey,
+                                                 const void **inFirstValue,
+                                                 const size_t &inCount,
+                                                 CFMutableDictionaryRef &inOutDictionary);
+    void TestArrayCreateWithValues(const void **inFirstValue,
+                                   const size_t &inCount,
+                                   CFMutableArrayRef &outArray);
+    void TestDictionaryCreateWithKeysAndValues(const void **inFirstKey,
+                                               const void **inFirstValue,
+                                               const size_t &inCount,
+                                               CFMutableDictionaryRef &outDictionary);
+    void TestSetup(const void **inFirstBaseDictionaryKey,
+                   const void **inFirstBaseDictionaryValue,
+                   const size_t &inBaseDictionaryCount,
+                   CFMutableDictionaryRef &outBaseDictionaryRef,
+                   const void **inFirstAddedDictionaryKey,
+                   const void **inFirstAddedDictionaryValue,
+                   const size_t &inAddedDictionaryCount,
+                   CFMutableDictionaryRef &outAddedDictionaryRef,
+                   const void **inFirstCommonDictionaryKey,
+                   const void **inFirstCommonDictionaryValue,
+                   const size_t &inCommonDictionaryCount,
+                   CFMutableDictionaryRef &outCommonDictionaryRef,
+                   const void **inFirstRemovedDictionaryKey,
+                   const void **inFirstRemovedDictionaryValue,
+                   const size_t &inRemovedDictionaryCount,
+                   CFMutableDictionaryRef &outRemovedDictionaryRef,
+                   const void **inFirstRemovedKeysArrayKey,
+                   const size_t &inRemovedKeysArrayCount,
+                   CFMutableArrayRef &outRemovedKeysArrayRef);
+    void TestDictionaryKeysAndValues(CFDictionaryRef inDictionary,
+                                     const void **inExpectedFirstKey,
+                                     const void **inExpectedFirstValue,
+                                     const size_t &inExpectedCount);
+    void TestTeardown(CFMutableDictionaryRef &inBaseDictionaryRef,
+                      CFMutableDictionaryRef &inAddedDictionaryRef,
+                      CFMutableDictionaryRef &inCommonDictionaryRef,
+                      CFMutableDictionaryRef &inRemovedDictionaryRef,
+                      CFMutableArrayRef &inRemovedKeysArrayRef);
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION(TestCFUDictionaryMergeWithDifferences);
+
+void
+TestCFUDictionaryMergeWithDifferences :: TestNull(void)
+{
+    CFMutableDictionaryRef lBaseDictionaryRef     = nullptr;
+    CFMutableDictionaryRef lAddedDictionaryRef    = nullptr;
+    CFMutableDictionaryRef lCommonDictionaryRef   = nullptr;
+    CFMutableDictionaryRef lRemovedDictionaryRef  = nullptr;
+    CFMutableArrayRef      lRemovedKeysArrayRef   = nullptr;
+    Boolean                lStatus;
+
+    // Test Setup
+
+    TestSetup(nullptr,
+              nullptr,
+              0,
+              lBaseDictionaryRef,
+              nullptr,
+              nullptr,
+              0,
+              lAddedDictionaryRef,
+              nullptr,
+              nullptr,
+              0,
+              lCommonDictionaryRef,
+              nullptr,
+              nullptr,
+              0,
+              lRemovedDictionaryRef,
+              nullptr,
+              0,
+              lRemovedKeysArrayRef);
+
+    // C Bindings
+
+    lStatus = CFUDictionaryMergeWithDifferences(nullptr,
+                                                lAddedDictionaryRef,
+                                                lCommonDictionaryRef,
+                                                lRemovedDictionaryRef);
+    CPPUNIT_ASSERT(lStatus == false);
+
+    lStatus = CFUDictionaryMergeWithDifferencesAndRemovedKeys(nullptr,
+                                                              lAddedDictionaryRef,
+                                                              lCommonDictionaryRef,
+                                                              lRemovedKeysArrayRef);
+    CPPUNIT_ASSERT(lStatus == false);
+
+    // C++ Bindings
+
+    lStatus = CFUDictionaryMerge(nullptr,
+                                 lAddedDictionaryRef,
+                                 lCommonDictionaryRef,
+                                 lRemovedDictionaryRef);
+    CPPUNIT_ASSERT(lStatus == false);
+
+    lStatus = CFUDictionaryMerge(nullptr,
+                                 lAddedDictionaryRef,
+                                 lCommonDictionaryRef,
+                                 lRemovedKeysArrayRef);
+    CPPUNIT_ASSERT(lStatus == false);
+
+    // Test Teardown
+
+    TestTeardown(lBaseDictionaryRef,
+                 lAddedDictionaryRef,
+                 lCommonDictionaryRef,
+                 lRemovedDictionaryRef,
+                 lRemovedKeysArrayRef);
+}
+
+void
+TestCFUDictionaryMergeWithDifferences :: TestBaseWithNoDifferences(void)
+{
+    constexpr size_t       kBaseKeyCount              = 2;
+    const void *           kBaseKeys[kBaseKeyCount]   = {
+        CFSTR("Test Key 2"),
+        CFSTR("Test Key 4")
+    };
+    const void *           kBaseValues[kBaseKeyCount] = {
+        CFSTR("Test Value 2"),
+        CFSTR("Test Value 4")
+    };
+    CFMutableDictionaryRef lBaseDictionaryRef         = nullptr;
+    CFMutableDictionaryRef lAddedDictionaryRef        = nullptr;
+    CFMutableDictionaryRef lCommonDictionaryRef       = nullptr;
+    CFMutableDictionaryRef lRemovedDictionaryRef      = nullptr;
+    CFMutableArrayRef      lRemovedKeysArrayRef       = nullptr;
+    Boolean                lStatus;
+
+    // Test Setup
+
+    TestSetup(&kBaseKeys[0],
+              &kBaseValues[0],
+              kBaseKeyCount,
+              lBaseDictionaryRef,
+              nullptr,
+              nullptr,
+              0,
+              lAddedDictionaryRef,
+              nullptr,
+              nullptr,
+              0,
+              lCommonDictionaryRef,
+              nullptr,
+              nullptr,
+              0,
+              lRemovedDictionaryRef,
+              nullptr,
+              0,
+              lRemovedKeysArrayRef);
+
+    // C Bindings
+
+    lStatus = CFUDictionaryMergeWithDifferences(lBaseDictionaryRef,
+                                                nullptr,
+                                                nullptr,
+                                                nullptr);
+    CPPUNIT_ASSERT(lStatus == true);
+
+    // Validate the base dictionary keys and values are as expected
+    // after the merge.
+    //
+    // There were no differences applied, so the expected key/value
+    // pairs should be exactly those of the base.
+
+    TestDictionaryKeysAndValues(lBaseDictionaryRef,
+                                &kBaseKeys[0],
+                                &kBaseValues[0],
+                                kBaseKeyCount);
+
+    lStatus = CFUDictionaryMergeWithDifferencesAndRemovedKeys(lBaseDictionaryRef,
+                                                              nullptr,
+                                                              nullptr,
+                                                              nullptr);
+    CPPUNIT_ASSERT(lStatus == true);
+
+    // Validate the base dictionary keys and values are as expected
+    // after the merge.
+    //
+    // There were no differences applied, so the expected key/value
+    // pairs should be exactly those of the base.
+
+    TestDictionaryKeysAndValues(lBaseDictionaryRef,
+                                &kBaseKeys[0],
+                                &kBaseValues[0],
+                                kBaseKeyCount);
+
+    // C++ Bindings
+
+    lStatus = CFUDictionaryMerge(lBaseDictionaryRef,
+                                 nullptr,
+                                 nullptr,
+                                 static_cast<CFMutableDictionaryRef>(nullptr));
+    CPPUNIT_ASSERT(lStatus == true);
+
+    // Validate the base dictionary keys and values are as expected
+    // after the merge.
+    //
+    // There were no differences applied, so the expected key/value
+    // pairs should be exactly those of the base.
+
+    TestDictionaryKeysAndValues(lBaseDictionaryRef,
+                                &kBaseKeys[0],
+                                &kBaseValues[0],
+                                kBaseKeyCount);
+
+    lStatus = CFUDictionaryMerge(lBaseDictionaryRef,
+                                 nullptr,
+                                 nullptr,
+                                 static_cast<CFMutableArrayRef>(nullptr));
+    CPPUNIT_ASSERT(lStatus == true);
+
+    // Validate the base dictionary keys and values are as expected
+    // after the merge.
+    //
+    // There were no differences applied, so the expected key/value
+    // pairs should be exactly those of the base.
+
+    TestDictionaryKeysAndValues(lBaseDictionaryRef,
+                                &kBaseKeys[0],
+                                &kBaseValues[0],
+                                kBaseKeyCount);
+
+    // Test Teardown
+
+    TestTeardown(lBaseDictionaryRef,
+                 lAddedDictionaryRef,
+                 lCommonDictionaryRef,
+                 lRemovedDictionaryRef,
+                 lRemovedKeysArrayRef);
+}
+
+void
+TestCFUDictionaryMergeWithDifferences :: TestBaseWithAddedOnly(void)
+{
+    constexpr size_t       kBaseKeyCount                      = 2;
+    const void *           kBaseKeys[kBaseKeyCount]           = {
+        CFSTR("Test Key 2"),
+        CFSTR("Test Key 4")
+    };
+    const void *           kBaseValues[kBaseKeyCount]         = {
+        CFSTR("Test Value 2"),
+        CFSTR("Test Value 4")
+    };
+    CFMutableDictionaryRef lBaseDictionaryRef                 = nullptr;
+    constexpr size_t       kAddedKeyCount                     = 2;
+    const void *           kAddedKeys[kAddedKeyCount]         = {
+        CFSTR("Test Key 1"),
+        CFSTR("Test Key 3")
+    };
+    const void *           kAddedValues[kAddedKeyCount]       = {
+        CFSTR("Test Value 1"),
+        CFSTR("Test Value 3")
+    };
+    CFMutableDictionaryRef lAddedDictionaryRef                = nullptr;
+    CFMutableDictionaryRef lCommonDictionaryRef               = nullptr;
+    CFMutableDictionaryRef lRemovedDictionaryRef              = nullptr;
+    CFMutableArrayRef      lRemovedKeysArrayRef               = nullptr;
+    constexpr size_t       kExpectedKeyCount                  = 4;
+    const void *           kExpectedKeys[kExpectedKeyCount]   = {
+        CFSTR("Test Key 1"),
+        CFSTR("Test Key 2"),
+        CFSTR("Test Key 3"),
+        CFSTR("Test Key 4")
+    };
+    const void *           kExpectedValues[kExpectedKeyCount] = {
+        CFSTR("Test Value 1"),
+        CFSTR("Test Value 2"),
+        CFSTR("Test Value 3"),
+        CFSTR("Test Value 4")
+    };
+    Boolean                lStatus;
+
+    // Test Setup
+
+    TestSetup(&kBaseKeys[0],
+              &kBaseValues[0],
+              kBaseKeyCount,
+              lBaseDictionaryRef,
+              &kAddedKeys[0],
+              &kAddedValues[0],
+              kAddedKeyCount,
+              lAddedDictionaryRef,
+              nullptr,
+              nullptr,
+              0,
+              lCommonDictionaryRef,
+              nullptr,
+              nullptr,
+              0,
+              lRemovedDictionaryRef,
+              nullptr,
+              0,
+              lRemovedKeysArrayRef);
+
+    // C Bindings
+
+    lStatus = CFUDictionaryMergeWithDifferences(lBaseDictionaryRef,
+                                                lAddedDictionaryRef,
+                                                nullptr,
+                                                nullptr);
+    CPPUNIT_ASSERT(lStatus == true);
+
+    // Validate the base dictionary keys and values are as expected
+    // after the merge.
+    //
+    // Only keys were added, so the expected key/value pairs should be
+    // the union of the base and added keys.
+
+    TestDictionaryKeysAndValues(lBaseDictionaryRef,
+                                &kExpectedKeys[0],
+                                &kExpectedValues[0],
+                                kExpectedKeyCount);
+
+    // Clear the base dictionary and reestablish the baseline pre-test
+    // key/value pairs.
+
+    CFDictionaryRemoveAllValues(lBaseDictionaryRef);
+
+    TestDictionaryPopulateWithKeysAndValues(&kBaseKeys[0],
+                                            &kBaseValues[0],
+                                            kBaseKeyCount,
+                                            lBaseDictionaryRef);
+
+    lStatus = CFUDictionaryMergeWithDifferencesAndRemovedKeys(lBaseDictionaryRef,
+                                                              lAddedDictionaryRef,
+                                                              nullptr,
+                                                              nullptr);
+    CPPUNIT_ASSERT(lStatus == true);
+
+    // Validate the base dictionary keys and values are as expected
+    // after the merge.
+    //
+    // Only keys were added, so the expected key/value pairs should be
+    // the union of the base and added keys.
+
+    TestDictionaryKeysAndValues(lBaseDictionaryRef,
+                                &kExpectedKeys[0],
+                                &kExpectedValues[0],
+                                kExpectedKeyCount);
+
+    // C++ Bindings
+
+    // Clear the base dictionary and reestablish the baseline pre-test
+    // key/value pairs.
+
+    CFDictionaryRemoveAllValues(lBaseDictionaryRef);
+
+    TestDictionaryPopulateWithKeysAndValues(&kBaseKeys[0],
+                                            &kBaseValues[0],
+                                            kBaseKeyCount,
+                                            lBaseDictionaryRef);
+
+    lStatus = CFUDictionaryMerge(lBaseDictionaryRef,
+                                 lAddedDictionaryRef,
+                                 nullptr,
+                                 static_cast<CFMutableDictionaryRef>(nullptr));
+    CPPUNIT_ASSERT(lStatus == true);
+
+    // Validate the base dictionary keys and values are as expected
+    // after the merge.
+    //
+    // Only keys were added, so the expected key/value pairs should be
+    // the union of the base and added keys.
+
+    TestDictionaryKeysAndValues(lBaseDictionaryRef,
+                                &kExpectedKeys[0],
+                                &kExpectedValues[0],
+                                kExpectedKeyCount);
+
+    // Clear the base dictionary and reestablish the baseline pre-test
+    // key/value pairs.
+
+    CFDictionaryRemoveAllValues(lBaseDictionaryRef);
+
+    TestDictionaryPopulateWithKeysAndValues(&kBaseKeys[0],
+                                            &kBaseValues[0],
+                                            kBaseKeyCount,
+                                            lBaseDictionaryRef);
+
+    lStatus = CFUDictionaryMerge(lBaseDictionaryRef,
+                                 lAddedDictionaryRef,
+                                 nullptr,
+                                 static_cast<CFMutableArrayRef>(nullptr));
+    CPPUNIT_ASSERT(lStatus == true);
+
+    // Validate the base dictionary keys and values are as expected
+    // after the merge.
+    //
+    // Only keys were added, so the expected key/value pairs should be
+    // the union of the base and added keys.
+
+    TestDictionaryKeysAndValues(lBaseDictionaryRef,
+                                &kExpectedKeys[0],
+                                &kExpectedValues[0],
+                                kExpectedKeyCount);
+
+    // Test Teardown
+
+    TestTeardown(lBaseDictionaryRef,
+                 lAddedDictionaryRef,
+                 lCommonDictionaryRef,
+                 lRemovedDictionaryRef,
+                 lRemovedKeysArrayRef);
+}
+
+void
+TestCFUDictionaryMergeWithDifferences :: TestBaseWithCommonOnly(void)
+{
+    constexpr size_t       kBaseKeyCount                      = 2;
+    const void *           kBaseKeys[kBaseKeyCount]           = {
+        CFSTR("Test Key 2"),
+        CFSTR("Test Key 4")
+    };
+    const void *           kBaseValues[kBaseKeyCount]         = {
+        CFSTR("Test Value 2"),
+        CFSTR("Test Value 4")
+    };
+    CFMutableDictionaryRef lBaseDictionaryRef                 = nullptr;
+    CFMutableDictionaryRef lAddedDictionaryRef                = nullptr;
+    constexpr size_t       kCommonKeyCount                    = 2;
+    const void *           kCommonKeys[kCommonKeyCount]       = {
+        CFSTR("Test Key 2"),
+        CFSTR("Test Key 4")
+    };
+    const void *           kCommonValues[kCommonKeyCount]     = {
+        CFSTR("Test Value 2"),
+        CFSTR("Test Value 4")
+    };
+    CFMutableDictionaryRef lCommonDictionaryRef               = nullptr;
+    CFMutableDictionaryRef lRemovedDictionaryRef              = nullptr;
+    CFMutableArrayRef      lRemovedKeysArrayRef               = nullptr;
+    Boolean                lStatus;
+
+    // Test Setup
+
+    TestSetup(&kBaseKeys[0],
+              &kBaseValues[0],
+              kBaseKeyCount,
+              lBaseDictionaryRef,
+              nullptr,
+              nullptr,
+              0,
+              lAddedDictionaryRef,
+              &kCommonKeys[0],
+              &kCommonValues[0],
+              kCommonKeyCount,
+              lCommonDictionaryRef,
+              nullptr,
+              nullptr,
+              0,
+              lRemovedDictionaryRef,
+              nullptr,
+              0,
+              lRemovedKeysArrayRef);
+
+    // C Bindings
+
+    lStatus = CFUDictionaryMergeWithDifferences(lBaseDictionaryRef,
+                                                nullptr,
+                                                lCommonDictionaryRef,
+                                                nullptr);
+    CPPUNIT_ASSERT(lStatus == true);
+
+    // Validate the base dictionary keys and values are as expected
+    // after the merge.
+    //
+    // No keys were added or removed and the common dictionary is
+    // identical to the base dictionary, so the expected key/value
+    // pairs should be exactly that of the base.
+
+    TestDictionaryKeysAndValues(lBaseDictionaryRef,
+                                &kBaseKeys[0],
+                                &kBaseValues[0],
+                                kBaseKeyCount);
+
+    // Clear the base dictionary and reestablish the baseline pre-test
+    // key/value pairs.
+
+    CFDictionaryRemoveAllValues(lBaseDictionaryRef);
+
+    TestDictionaryPopulateWithKeysAndValues(&kBaseKeys[0],
+                                            &kBaseValues[0],
+                                            kBaseKeyCount,
+                                            lBaseDictionaryRef);
+
+    lStatus = CFUDictionaryMergeWithDifferencesAndRemovedKeys(lBaseDictionaryRef,
+                                                              nullptr,
+                                                              lCommonDictionaryRef,
+                                                              nullptr);
+    CPPUNIT_ASSERT(lStatus == true);
+
+    // Validate the base dictionary keys and values are as expected
+    // after the merge.
+    //
+    // No keys were added or removed and the common dictionary is
+    // identical to the base dictionary, so the expected key/value
+    // pairs should be exactly that of the base.
+
+    TestDictionaryKeysAndValues(lBaseDictionaryRef,
+                                &kBaseKeys[0],
+                                &kBaseValues[0],
+                                kBaseKeyCount);
+
+    // C++ Bindings
+
+    // Clear the base dictionary and reestablish the baseline pre-test
+    // key/value pairs.
+
+    CFDictionaryRemoveAllValues(lBaseDictionaryRef);
+
+    TestDictionaryPopulateWithKeysAndValues(&kBaseKeys[0],
+                                            &kBaseValues[0],
+                                            kBaseKeyCount,
+                                            lBaseDictionaryRef);
+
+    lStatus = CFUDictionaryMerge(lBaseDictionaryRef,
+                                 nullptr,
+                                 lCommonDictionaryRef,
+                                 static_cast<CFMutableDictionaryRef>(nullptr));
+    CPPUNIT_ASSERT(lStatus == true);
+
+    // Validate the base dictionary keys and values are as expected
+    // after the merge.
+    //
+    // No keys were added or removed and the common dictionary is
+    // identical to the base dictionary, so the expected key/value
+    // pairs should be exactly that of the base.
+
+    TestDictionaryKeysAndValues(lBaseDictionaryRef,
+                                &kBaseKeys[0],
+                                &kBaseValues[0],
+                                kBaseKeyCount);
+
+    // Clear the base dictionary and reestablish the baseline pre-test
+    // key/value pairs.
+
+    CFDictionaryRemoveAllValues(lBaseDictionaryRef);
+
+    TestDictionaryPopulateWithKeysAndValues(&kBaseKeys[0],
+                                            &kBaseValues[0],
+                                            kBaseKeyCount,
+                                            lBaseDictionaryRef);
+
+    lStatus = CFUDictionaryMerge(lBaseDictionaryRef,
+                                 nullptr,
+                                 lCommonDictionaryRef,
+                                 static_cast<CFMutableArrayRef>(nullptr));
+    CPPUNIT_ASSERT(lStatus == true);
+
+    // Validate the base dictionary keys and values are as expected
+    // after the merge.
+    //
+    // No keys were added or removed and the common dictionary is
+    // identical to the base dictionary, so the expected key/value
+    // pairs should be exactly that of the base.
+
+    TestDictionaryKeysAndValues(lBaseDictionaryRef,
+                                &kBaseKeys[0],
+                                &kBaseValues[0],
+                                kBaseKeyCount);
+
+    // Test Teardown
+
+    TestTeardown(lBaseDictionaryRef,
+                 lAddedDictionaryRef,
+                 lCommonDictionaryRef,
+                 lRemovedDictionaryRef,
+                 lRemovedKeysArrayRef);
+}
+
+void
+TestCFUDictionaryMergeWithDifferences :: TestBaseWithRemovedOnly(void)
+{
+    constexpr size_t       kBaseKeyCount                      = 2;
+    const void *           kBaseKeys[kBaseKeyCount]           = {
+        CFSTR("Test Key 2"),
+        CFSTR("Test Key 4")
+    };
+    const void *           kBaseValues[kBaseKeyCount]         = {
+        CFSTR("Test Value 2"),
+        CFSTR("Test Value 4")
+    };
+    CFMutableDictionaryRef lBaseDictionaryRef                 = nullptr;
+    CFMutableDictionaryRef lAddedDictionaryRef                = nullptr;
+    CFMutableDictionaryRef lCommonDictionaryRef               = nullptr;
+    constexpr size_t       kRemovedKeyCount                   = 2;
+    const void *           kRemovedKeys[kRemovedKeyCount]     = {
+        CFSTR("Test Key 2"),
+        CFSTR("Test Key 4")
+    };
+    const void *           kRemovedValues[kRemovedKeyCount]   = {
+        CFSTR("Test Value 2"),
+        CFSTR("Test Value 4")
+    };
+    CFMutableDictionaryRef lRemovedDictionaryRef              = nullptr;
+    CFMutableArrayRef      lRemovedKeysArrayRef               = nullptr;
+    Boolean                lStatus;
+
+    // Test Setup
+
+    TestSetup(&kBaseKeys[0],
+              &kBaseValues[0],
+              kBaseKeyCount,
+              lBaseDictionaryRef,
+              nullptr,
+              nullptr,
+              0,
+              lAddedDictionaryRef,
+              nullptr,
+              nullptr,
+              0,
+              lCommonDictionaryRef,
+              &kRemovedKeys[0],
+              &kRemovedValues[0],
+              kRemovedKeyCount,
+              lRemovedDictionaryRef,
+              &kRemovedKeys[0],
+              kRemovedKeyCount,
+              lRemovedKeysArrayRef);
+
+    // C Bindings
+
+    lStatus = CFUDictionaryMergeWithDifferences(lBaseDictionaryRef,
+                                                nullptr,
+                                                nullptr,
+                                                lRemovedDictionaryRef);
+    CPPUNIT_ASSERT(lStatus == true);
+
+    // Validate the base dictionary keys and values are as expected
+    // after the merge.
+    //
+    // Only keys were removed, so the expected key/value pairs should
+    // be zero.
+
+    TestDictionaryKeysAndValues(lBaseDictionaryRef,
+                                nullptr,
+                                nullptr,
+                                0);
+
+    // Clear the base dictionary and reestablish the baseline pre-test
+    // key/value pairs.
+
+    CFDictionaryRemoveAllValues(lBaseDictionaryRef);
+
+    TestDictionaryPopulateWithKeysAndValues(&kBaseKeys[0],
+                                            &kBaseValues[0],
+                                            kBaseKeyCount,
+                                            lBaseDictionaryRef);
+
+    lStatus = CFUDictionaryMergeWithDifferencesAndRemovedKeys(lBaseDictionaryRef,
+                                                              nullptr,
+                                                              nullptr,
+                                                              lRemovedKeysArrayRef);
+    CPPUNIT_ASSERT(lStatus == true);
+
+    // Validate the base dictionary keys and values are as expected
+    // after the merge.
+    //
+    // Only keys were removed, so the expected key/value pairs should
+    // be zero.
+
+    TestDictionaryKeysAndValues(lBaseDictionaryRef,
+                                nullptr,
+                                nullptr,
+                                0);
+
+    // C++ Bindings
+
+    // Clear the base dictionary and reestablish the baseline pre-test
+    // key/value pairs.
+
+    CFDictionaryRemoveAllValues(lBaseDictionaryRef);
+
+    TestDictionaryPopulateWithKeysAndValues(&kBaseKeys[0],
+                                            &kBaseValues[0],
+                                            kBaseKeyCount,
+                                            lBaseDictionaryRef);
+
+    lStatus = CFUDictionaryMerge(lBaseDictionaryRef,
+                                 nullptr,
+                                 nullptr,
+                                 lRemovedDictionaryRef);
+    CPPUNIT_ASSERT(lStatus == true);
+
+    // Validate the base dictionary keys and values are as expected
+    // after the merge.
+    //
+    // Only keys were removed, so the expected key/value pairs should
+    // be zero.
+
+    TestDictionaryKeysAndValues(lBaseDictionaryRef,
+                                nullptr,
+                                nullptr,
+                                0);
+
+    // Clear the base dictionary and reestablish the baseline pre-test
+    // key/value pairs.
+
+    CFDictionaryRemoveAllValues(lBaseDictionaryRef);
+
+    TestDictionaryPopulateWithKeysAndValues(&kBaseKeys[0],
+                                            &kBaseValues[0],
+                                            kBaseKeyCount,
+                                            lBaseDictionaryRef);
+
+    lStatus = CFUDictionaryMerge(lBaseDictionaryRef,
+                                 nullptr,
+                                 nullptr,
+                                 lRemovedKeysArrayRef);
+    CPPUNIT_ASSERT(lStatus == true);
+
+    // Validate the base dictionary keys and values are as expected
+    // after the merge.
+    //
+    // Only keys were removed, so the expected key/value pairs should
+    // be zero.
+
+    TestDictionaryKeysAndValues(lBaseDictionaryRef,
+                                nullptr,
+                                nullptr,
+                                0);
+
+    // Test Teardown
+
+    TestTeardown(lBaseDictionaryRef,
+                 lAddedDictionaryRef,
+                 lCommonDictionaryRef,
+                 lRemovedDictionaryRef,
+                 lRemovedKeysArrayRef);
+}
+
+void
+TestCFUDictionaryMergeWithDifferences :: TestBaseWithAddedAndCommonOnly(void)
+{
+    constexpr size_t       kBaseKeyCount                      = 2;
+    const void *           kBaseKeys[kBaseKeyCount]           = {
+        CFSTR("Test Key 2"),
+        CFSTR("Test Key 4")
+    };
+    const void *           kBaseValues[kBaseKeyCount]         = {
+        CFSTR("Test Value 2"),
+        CFSTR("Test Value 4")
+    };
+    CFMutableDictionaryRef lBaseDictionaryRef                 = nullptr;
+    constexpr size_t       kAddedKeyCount                     = 2;
+    const void *           kAddedKeys[kAddedKeyCount]         = {
+        CFSTR("Test Key 1"),
+        CFSTR("Test Key 3")
+    };
+    const void *           kAddedValues[kAddedKeyCount]       = {
+        CFSTR("Test Value 1"),
+        CFSTR("Test Value 3")
+    };
+    CFMutableDictionaryRef lAddedDictionaryRef                = nullptr;
+    constexpr size_t       kCommonKeyCount                    = 2;
+    const void *           kCommonKeys[kCommonKeyCount]       = {
+        CFSTR("Test Key 2"),
+        CFSTR("Test Key 4")
+    };
+    const void *           kCommonValues[kCommonKeyCount]     = {
+        CFSTR("Test Value 2"),
+        CFSTR("Test Value 4")
+    };
+    CFMutableDictionaryRef lCommonDictionaryRef               = nullptr;
+    CFMutableDictionaryRef lRemovedDictionaryRef              = nullptr;
+    CFMutableArrayRef      lRemovedKeysArrayRef               = nullptr;
+    constexpr size_t       kExpectedKeyCount                  = 4;
+    const void *           kExpectedKeys[kExpectedKeyCount]   = {
+        CFSTR("Test Key 1"),
+        CFSTR("Test Key 2"),
+        CFSTR("Test Key 3"),
+        CFSTR("Test Key 4")
+    };
+    const void *           kExpectedValues[kExpectedKeyCount] = {
+        CFSTR("Test Value 1"),
+        CFSTR("Test Value 2"),
+        CFSTR("Test Value 3"),
+        CFSTR("Test Value 4")
+    };
+    Boolean                lStatus;
+
+    // Test Setup
+
+    TestSetup(&kBaseKeys[0],
+              &kBaseValues[0],
+              kBaseKeyCount,
+              lBaseDictionaryRef,
+              &kAddedKeys[0],
+              &kAddedValues[0],
+              kAddedKeyCount,
+              lAddedDictionaryRef,
+              &kCommonKeys[0],
+              &kCommonValues[0],
+              kCommonKeyCount,
+              lCommonDictionaryRef,
+              nullptr,
+              nullptr,
+              0,
+              lRemovedDictionaryRef,
+              nullptr,
+              0,
+              lRemovedKeysArrayRef);
+
+    // C Bindings
+
+    lStatus = CFUDictionaryMergeWithDifferences(lBaseDictionaryRef,
+                                                lAddedDictionaryRef,
+                                                lCommonDictionaryRef,
+                                                nullptr);
+    CPPUNIT_ASSERT(lStatus == true);
+
+    // Validate the base dictionary keys and values are as expected
+    // after the merge.
+    //
+    // Keys were added and the common dictionary is identical to the
+    // base dictionary, so the expected key/value pairs should be the
+    // union of the base and added keys.
+
+    TestDictionaryKeysAndValues(lBaseDictionaryRef,
+                                &kExpectedKeys[0],
+                                &kExpectedValues[0],
+                                kExpectedKeyCount);
+
+    // Clear the base dictionary and reestablish the baseline pre-test
+    // key/value pairs.
+
+    CFDictionaryRemoveAllValues(lBaseDictionaryRef);
+
+    TestDictionaryPopulateWithKeysAndValues(&kBaseKeys[0],
+                                            &kBaseValues[0],
+                                            kBaseKeyCount,
+                                            lBaseDictionaryRef);
+
+    lStatus = CFUDictionaryMergeWithDifferencesAndRemovedKeys(lBaseDictionaryRef,
+                                                              lAddedDictionaryRef,
+                                                              lCommonDictionaryRef,
+                                                              nullptr);
+    CPPUNIT_ASSERT(lStatus == true);
+
+    // Validate the base dictionary keys and values are as expected
+    // after the merge.
+    //
+    // Keys were added and the common dictionary is identical to the
+    // base dictionary, so the expected key/value pairs should be the
+    // union of the base and added keys.
+
+    TestDictionaryKeysAndValues(lBaseDictionaryRef,
+                                &kExpectedKeys[0],
+                                &kExpectedValues[0],
+                                kExpectedKeyCount);
+
+    // C++ Bindings
+
+    // Clear the base dictionary and reestablish the baseline pre-test
+    // key/value pairs.
+
+    CFDictionaryRemoveAllValues(lBaseDictionaryRef);
+
+    TestDictionaryPopulateWithKeysAndValues(&kBaseKeys[0],
+                                            &kBaseValues[0],
+                                            kBaseKeyCount,
+                                            lBaseDictionaryRef);
+
+    lStatus = CFUDictionaryMerge(lBaseDictionaryRef,
+                                 lAddedDictionaryRef,
+                                 lCommonDictionaryRef,
+                                 static_cast<CFMutableDictionaryRef>(nullptr));
+    CPPUNIT_ASSERT(lStatus == true);
+
+    // Validate the base dictionary keys and values are as expected
+    // after the merge.
+    //
+    // Keys were added and the common dictionary is identical to the
+    // base dictionary, so the expected key/value pairs should be the
+    // union of the base and added keys.
+
+    TestDictionaryKeysAndValues(lBaseDictionaryRef,
+                                &kExpectedKeys[0],
+                                &kExpectedValues[0],
+                                kExpectedKeyCount);
+
+    // Clear the base dictionary and reestablish the baseline pre-test
+    // key/value pairs.
+
+    CFDictionaryRemoveAllValues(lBaseDictionaryRef);
+
+    TestDictionaryPopulateWithKeysAndValues(&kBaseKeys[0],
+                                            &kBaseValues[0],
+                                            kBaseKeyCount,
+                                            lBaseDictionaryRef);
+
+    lStatus = CFUDictionaryMerge(lBaseDictionaryRef,
+                                 lAddedDictionaryRef,
+                                 lCommonDictionaryRef,
+                                 static_cast<CFMutableArrayRef>(nullptr));
+    CPPUNIT_ASSERT(lStatus == true);
+
+    // Validate the base dictionary keys and values are as expected
+    // after the merge.
+    //
+    // Keys were added and the common dictionary is identical to the
+    // base dictionary, so the expected key/value pairs should be the
+    // union of the base and added keys.
+
+    TestDictionaryKeysAndValues(lBaseDictionaryRef,
+                                &kExpectedKeys[0],
+                                &kExpectedValues[0],
+                                kExpectedKeyCount);
+
+    // Test Teardown
+
+    TestTeardown(lBaseDictionaryRef,
+                 lAddedDictionaryRef,
+                 lCommonDictionaryRef,
+                 lRemovedDictionaryRef,
+                 lRemovedKeysArrayRef);
+}
+
+void
+TestCFUDictionaryMergeWithDifferences :: TestBaseWithAddedAndRemovedOnly(void)
+{
+    constexpr size_t       kBaseKeyCount                      = 2;
+    const void *           kBaseKeys[kBaseKeyCount]           = {
+        CFSTR("Test Key 2"),
+        CFSTR("Test Key 4")
+    };
+    const void *           kBaseValues[kBaseKeyCount]         = {
+        CFSTR("Test Value 2"),
+        CFSTR("Test Value 4")
+    };
+    CFMutableDictionaryRef lBaseDictionaryRef                 = nullptr;
+    constexpr size_t       kAddedKeyCount                     = 2;
+    const void *           kAddedKeys[kAddedKeyCount]         = {
+        CFSTR("Test Key 1"),
+        CFSTR("Test Key 3")
+    };
+    const void *           kAddedValues[kAddedKeyCount]       = {
+        CFSTR("Test Value 1"),
+        CFSTR("Test Value 3")
+    };
+    CFMutableDictionaryRef lAddedDictionaryRef                = nullptr;
+    CFMutableDictionaryRef lCommonDictionaryRef               = nullptr;
+    constexpr size_t       kRemovedKeyCount                   = 2;
+    const void *           kRemovedKeys[kRemovedKeyCount]     = {
+        CFSTR("Test Key 2"),
+        CFSTR("Test Key 4")
+    };
+    const void *           kRemovedValues[kRemovedKeyCount]   = {
+        CFSTR("Test Value 2"),
+        CFSTR("Test Value 4")
+    };
+    CFMutableDictionaryRef lRemovedDictionaryRef              = nullptr;
+    CFMutableArrayRef      lRemovedKeysArrayRef               = nullptr;
+    Boolean                lStatus;
+
+    // Test Setup
+
+    TestSetup(&kBaseKeys[0],
+              &kBaseValues[0],
+              kBaseKeyCount,
+              lBaseDictionaryRef,
+              &kAddedKeys[0],
+              &kAddedValues[0],
+              kAddedKeyCount,
+              lAddedDictionaryRef,
+              nullptr,
+              nullptr,
+              0,
+              lCommonDictionaryRef,
+              &kRemovedKeys[0],
+              &kRemovedValues[0],
+              kRemovedKeyCount,
+              lRemovedDictionaryRef,
+              &kRemovedKeys[0],
+              kRemovedKeyCount,
+              lRemovedKeysArrayRef);
+
+    // C Bindings
+
+    lStatus = CFUDictionaryMergeWithDifferences(lBaseDictionaryRef,
+                                                lAddedDictionaryRef,
+                                                nullptr,
+                                                lRemovedDictionaryRef);
+    CPPUNIT_ASSERT(lStatus == true);
+
+    // Validate the base dictionary keys and values are as expected
+    // after the merge.
+    //
+    // Keys were both added and removed, so the expected key/value
+    // pairs should be the the added key/value pairs.
+
+    TestDictionaryKeysAndValues(lBaseDictionaryRef,
+                                &kAddedKeys[0],
+                                &kAddedValues[0],
+                                kAddedKeyCount);
+
+    // Clear the base dictionary and reestablish the baseline pre-test
+    // key/value pairs.
+
+    CFDictionaryRemoveAllValues(lBaseDictionaryRef);
+
+    TestDictionaryPopulateWithKeysAndValues(&kBaseKeys[0],
+                                            &kBaseValues[0],
+                                            kBaseKeyCount,
+                                            lBaseDictionaryRef);
+
+    lStatus = CFUDictionaryMergeWithDifferencesAndRemovedKeys(lBaseDictionaryRef,
+                                                              lAddedDictionaryRef,
+                                                              nullptr,
+                                                              lRemovedKeysArrayRef);
+    CPPUNIT_ASSERT(lStatus == true);
+
+    // Validate the base dictionary keys and values are as expected
+    // after the merge.
+    //
+    // Keys were both added and removed, so the expected key/value
+    // pairs should be the the added key/value pairs.
+
+    TestDictionaryKeysAndValues(lBaseDictionaryRef,
+                                &kAddedKeys[0],
+                                &kAddedValues[0],
+                                kAddedKeyCount);
+
+    // C++ Bindings
+
+    // Clear the base dictionary and reestablish the baseline pre-test
+    // key/value pairs.
+
+    CFDictionaryRemoveAllValues(lBaseDictionaryRef);
+
+    TestDictionaryPopulateWithKeysAndValues(&kBaseKeys[0],
+                                            &kBaseValues[0],
+                                            kBaseKeyCount,
+                                            lBaseDictionaryRef);
+
+    lStatus = CFUDictionaryMerge(lBaseDictionaryRef,
+                                 lAddedDictionaryRef,
+                                 nullptr,
+                                 lRemovedDictionaryRef);
+    CPPUNIT_ASSERT(lStatus == true);
+
+    // Validate the base dictionary keys and values are as expected
+    // after the merge.
+    //
+    // Keys were both added and removed, so the expected key/value
+    // pairs should be the the added key/value pairs.
+
+    TestDictionaryKeysAndValues(lBaseDictionaryRef,
+                                &kAddedKeys[0],
+                                &kAddedValues[0],
+                                kAddedKeyCount);
+
+    // Clear the base dictionary and reestablish the baseline pre-test
+    // key/value pairs.
+
+    CFDictionaryRemoveAllValues(lBaseDictionaryRef);
+
+    TestDictionaryPopulateWithKeysAndValues(&kBaseKeys[0],
+                                            &kBaseValues[0],
+                                            kBaseKeyCount,
+                                            lBaseDictionaryRef);
+
+    lStatus = CFUDictionaryMerge(lBaseDictionaryRef,
+                                 lAddedDictionaryRef,
+                                 nullptr,
+                                 lRemovedKeysArrayRef);
+    CPPUNIT_ASSERT(lStatus == true);
+
+    // Validate the base dictionary keys and values are as expected
+    // after the merge.
+    //
+    // Keys were both added and removed, so the expected key/value
+    // pairs should be the the added key/value pairs.
+
+    TestDictionaryKeysAndValues(lBaseDictionaryRef,
+                                &kAddedKeys[0],
+                                &kAddedValues[0],
+                                kAddedKeyCount);
+
+    // Test Teardown
+
+    TestTeardown(lBaseDictionaryRef,
+                 lAddedDictionaryRef,
+                 lCommonDictionaryRef,
+                 lRemovedDictionaryRef,
+                 lRemovedKeysArrayRef);
+}
+
+void
+TestCFUDictionaryMergeWithDifferences :: TestBaseWithCommonAndRemovedOnly(void)
+{
+    constexpr size_t       kBaseKeyCount                      = 4;
+    const void *           kBaseKeys[kBaseKeyCount]           = {
+        CFSTR("Test Key 2"),
+        CFSTR("Test Key 4"),
+        CFSTR("Test Key 5"),
+        CFSTR("Test Key 6")
+    };
+    const void *           kBaseValues[kBaseKeyCount]         = {
+        CFSTR("Test Value 2"),
+        CFSTR("Test Value 4"),
+        CFSTR("Test Value 5"),
+        CFSTR("Test Value 6")
+    };
+    CFMutableDictionaryRef lBaseDictionaryRef                 = nullptr;
+    CFMutableDictionaryRef lAddedDictionaryRef                = nullptr;
+    constexpr size_t       kCommonKeyCount                    = 2;
+    const void *           kCommonKeys[kCommonKeyCount]       = {
+        CFSTR("Test Key 5"),
+        CFSTR("Test Key 6")
+    };
+    const void *           kCommonValues[kCommonKeyCount]     = {
+        CFSTR("Test Value 5"),
+        CFSTR("Test Value 6")
+    };
+    CFMutableDictionaryRef lCommonDictionaryRef               = nullptr;
+    constexpr size_t       kRemovedKeyCount                   = 2;
+    const void *           kRemovedKeys[kRemovedKeyCount]     = {
+        CFSTR("Test Key 2"),
+        CFSTR("Test Key 4")
+    };
+    const void *           kRemovedValues[kRemovedKeyCount]   = {
+        CFSTR("Test Value 2"),
+        CFSTR("Test Value 4")
+    };
+    CFMutableDictionaryRef lRemovedDictionaryRef              = nullptr;
+    CFMutableArrayRef      lRemovedKeysArrayRef               = nullptr;
+    Boolean                lStatus;
+
+    // Test Setup
+
+    TestSetup(&kBaseKeys[0],
+              &kBaseValues[0],
+              kBaseKeyCount,
+              lBaseDictionaryRef,
+              nullptr,
+              nullptr,
+              0,
+              lAddedDictionaryRef,
+              &kCommonKeys[0],
+              &kCommonValues[0],
+              kCommonKeyCount,
+              lCommonDictionaryRef,
+              &kRemovedKeys[0],
+              &kRemovedValues[0],
+              kRemovedKeyCount,
+              lRemovedDictionaryRef,
+              &kRemovedKeys[0],
+              kRemovedKeyCount,
+              lRemovedKeysArrayRef);
+
+    // C Bindings
+
+    lStatus = CFUDictionaryMergeWithDifferences(lBaseDictionaryRef,
+                                                nullptr,
+                                                lCommonDictionaryRef,
+                                                lRemovedDictionaryRef);
+    CPPUNIT_ASSERT(lStatus == true);
+
+    // Validate the base dictionary keys and values are as expected
+    // after the merge.
+    //
+    // Keys were removed and the common dictionary is identical to the
+    // base dictionary, so the expected key/value pairs should
+    // be exaclty the common key/value pairs.
+
+    TestDictionaryKeysAndValues(lBaseDictionaryRef,
+                                &kCommonKeys[0],
+                                &kCommonValues[0],
+                                kCommonKeyCount);
+
+    // Clear the base dictionary and reestablish the baseline pre-test
+    // key/value pairs.
+
+    CFDictionaryRemoveAllValues(lBaseDictionaryRef);
+
+    TestDictionaryPopulateWithKeysAndValues(&kBaseKeys[0],
+                                            &kBaseValues[0],
+                                            kBaseKeyCount,
+                                            lBaseDictionaryRef);
+
+    lStatus = CFUDictionaryMergeWithDifferencesAndRemovedKeys(lBaseDictionaryRef,
+                                                              nullptr,
+                                                              lCommonDictionaryRef,
+                                                              lRemovedKeysArrayRef);
+    CPPUNIT_ASSERT(lStatus == true);
+
+    // Validate the base dictionary keys and values are as expected
+    // after the merge.
+    //
+    // Keys were removed and the common dictionary is identical to the
+    // base dictionary, so the expected key/value pairs should
+    // be exaclty the common key/value pairs.
+
+    TestDictionaryKeysAndValues(lBaseDictionaryRef,
+                                &kCommonKeys[0],
+                                &kCommonValues[0],
+                                kCommonKeyCount);
+
+    // C++ Bindings
+
+    // Clear the base dictionary and reestablish the baseline pre-test
+    // key/value pairs.
+
+    CFDictionaryRemoveAllValues(lBaseDictionaryRef);
+
+    TestDictionaryPopulateWithKeysAndValues(&kBaseKeys[0],
+                                            &kBaseValues[0],
+                                            kBaseKeyCount,
+                                            lBaseDictionaryRef);
+
+    lStatus = CFUDictionaryMerge(lBaseDictionaryRef,
+                                 nullptr,
+                                 lCommonDictionaryRef,
+                                 lRemovedDictionaryRef);
+    CPPUNIT_ASSERT(lStatus == true);
+
+    // Validate the base dictionary keys and values are as expected
+    // after the merge.
+    //
+    // Keys were removed and the common dictionary is identical to the
+    // base dictionary, so the expected key/value pairs should
+    // be exaclty the common key/value pairs.
+
+    TestDictionaryKeysAndValues(lBaseDictionaryRef,
+                                &kCommonKeys[0],
+                                &kCommonValues[0],
+                                kCommonKeyCount);
+
+    // Clear the base dictionary and reestablish the baseline pre-test
+    // key/value pairs.
+
+    CFDictionaryRemoveAllValues(lBaseDictionaryRef);
+
+    TestDictionaryPopulateWithKeysAndValues(&kBaseKeys[0],
+                                            &kBaseValues[0],
+                                            kBaseKeyCount,
+                                            lBaseDictionaryRef);
+
+    lStatus = CFUDictionaryMerge(lBaseDictionaryRef,
+                                 nullptr,
+                                 lCommonDictionaryRef,
+                                 lRemovedKeysArrayRef);
+    CPPUNIT_ASSERT(lStatus == true);
+
+    // Validate the base dictionary keys and values are as expected
+    // after the merge.
+    //
+    // Keys were removed and the common dictionary is identical to the
+    // base dictionary, so the expected key/value pairs should
+    // be exaclty the common key/value pairs.
+
+    TestDictionaryKeysAndValues(lBaseDictionaryRef,
+                                &kCommonKeys[0],
+                                &kCommonValues[0],
+                                kCommonKeyCount);
+
+    // Test Teardown
+
+    TestTeardown(lBaseDictionaryRef,
+                 lAddedDictionaryRef,
+                 lCommonDictionaryRef,
+                 lRemovedDictionaryRef,
+                 lRemovedKeysArrayRef);
+}
+
+void
+TestCFUDictionaryMergeWithDifferences :: TestBaseWithCommonDifferentValues(void)
+{
+    constexpr size_t       kBaseKeyCount                      = 4;
+    const void *           kBaseKeys[kBaseKeyCount]           = {
+        CFSTR("Test Key 2"),
+        CFSTR("Test Key 4"),
+        CFSTR("Test Key 5"),
+        CFSTR("Test Key 6")
+    };
+    const void *           kBaseValues[kBaseKeyCount]         = {
+        CFSTR("Test Value 2"),
+        CFSTR("Test Value 4"),
+        CFSTR("Test Value 5"),
+        CFSTR("Test Value 6")
+    };
+    CFMutableDictionaryRef lBaseDictionaryRef                 = nullptr;
+    constexpr size_t       kAddedKeyCount                     = 2;
+    const void *           kAddedKeys[kAddedKeyCount]         = {
+        CFSTR("Test Key 1"),
+        CFSTR("Test Key 3")
+    };
+    const void *           kAddedValues[kAddedKeyCount]       = {
+        CFSTR("Test Value 1"),
+        CFSTR("Test Value 3")
+    };
+    CFMutableDictionaryRef lAddedDictionaryRef                = nullptr;
+    constexpr size_t       kCommonKeyCount                    = 2;
+    const void *           kCommonKeys[kCommonKeyCount]       = {
+        CFSTR("Test Key 5"),
+        CFSTR("Test Key 6")
+    };
+    const void *           kCommonValues[kCommonKeyCount]     = {
+        CFSTR("Test Value 7"),
+        CFSTR("Test Value 8")
+    };
+    CFMutableDictionaryRef lCommonDictionaryRef               = nullptr;
+    constexpr size_t       kRemovedKeyCount                   = 2;
+    const void *           kRemovedKeys[kRemovedKeyCount]     = {
+        CFSTR("Test Key 2"),
+        CFSTR("Test Key 4")
+    };
+    const void *           kRemovedValues[kRemovedKeyCount]   = {
+        CFSTR("Test Value 2"),
+        CFSTR("Test Value 4")
+    };
+    CFMutableDictionaryRef lRemovedDictionaryRef              = nullptr;
+    CFMutableArrayRef      lRemovedKeysArrayRef               = nullptr;
+    constexpr size_t       kExpectedKeyCount                  = 4;
+    const void *           kExpectedKeys[kExpectedKeyCount]   = {
+        CFSTR("Test Key 1"),
+        CFSTR("Test Key 3"),
+        CFSTR("Test Key 5"),
+        CFSTR("Test Key 6")
+    };
+    const void *           kExpectedValues[kExpectedKeyCount] = {
+        CFSTR("Test Value 1"),
+        CFSTR("Test Value 3"),
+        CFSTR("Test Value 7"),
+        CFSTR("Test Value 8")
+    };
+    Boolean                lStatus;
+
+    // Test Setup
+
+    TestSetup(&kBaseKeys[0],
+              &kBaseValues[0],
+              kBaseKeyCount,
+              lBaseDictionaryRef,
+              &kAddedKeys[0],
+              &kAddedValues[0],
+              kAddedKeyCount,
+              lAddedDictionaryRef,
+              &kCommonKeys[0],
+              &kCommonValues[0],
+              kCommonKeyCount,
+              lCommonDictionaryRef,
+              &kRemovedKeys[0],
+              &kRemovedValues[0],
+              kRemovedKeyCount,
+              lRemovedDictionaryRef,
+              &kRemovedKeys[0],
+              kRemovedKeyCount,
+              lRemovedKeysArrayRef);
+
+    // C Bindings
+
+    lStatus = CFUDictionaryMergeWithDifferences(lBaseDictionaryRef,
+                                                lAddedDictionaryRef,
+                                                lCommonDictionaryRef,
+                                                lRemovedDictionaryRef);
+    CPPUNIT_ASSERT(lStatus == true);
+
+    CFShow(lBaseDictionaryRef);
+
+    // Validate the base dictionary keys and values are as expected
+    // after the merge.
+    //
+    // Keys were added, removed, and updated through common key/value
+    // pair conflicts, so the expected key/value pairs should be
+    // exaclty the those added plus those common key/value pairs
+    // changed.
+
+    TestDictionaryKeysAndValues(lBaseDictionaryRef,
+                                &kExpectedKeys[0],
+                                &kExpectedValues[0],
+                                kExpectedKeyCount);
+
+    // Clear the base dictionary and reestablish the baseline pre-test
+    // key/value pairs.
+
+    CFDictionaryRemoveAllValues(lBaseDictionaryRef);
+
+    TestDictionaryPopulateWithKeysAndValues(&kBaseKeys[0],
+                                            &kBaseValues[0],
+                                            kBaseKeyCount,
+                                            lBaseDictionaryRef);
+
+    lStatus = CFUDictionaryMergeWithDifferencesAndRemovedKeys(lBaseDictionaryRef,
+                                                              lAddedDictionaryRef,
+                                                              lCommonDictionaryRef,
+                                                              lRemovedKeysArrayRef);
+    CPPUNIT_ASSERT(lStatus == true);
+
+    // Validate the base dictionary keys and values are as expected
+    // after the merge.
+    //
+    // Keys were added, removed, and updated through common key/value
+    // pair conflicts, so the expected key/value pairs should be
+    // exaclty the those added plus those common key/value pairs
+    // changed.
+
+    TestDictionaryKeysAndValues(lBaseDictionaryRef,
+                                &kExpectedKeys[0],
+                                &kExpectedValues[0],
+                                kExpectedKeyCount);
+
+    // C++ Bindings
+
+    // Clear the base dictionary and reestablish the baseline pre-test
+    // key/value pairs.
+
+    CFDictionaryRemoveAllValues(lBaseDictionaryRef);
+
+    TestDictionaryPopulateWithKeysAndValues(&kBaseKeys[0],
+                                            &kBaseValues[0],
+                                            kBaseKeyCount,
+                                            lBaseDictionaryRef);
+
+    lStatus = CFUDictionaryMerge(lBaseDictionaryRef,
+                                 lAddedDictionaryRef,
+                                 lCommonDictionaryRef,
+                                 lRemovedDictionaryRef);
+    CPPUNIT_ASSERT(lStatus == true);
+
+    // Validate the base dictionary keys and values are as expected
+    // after the merge.
+    //
+    // Keys were added, removed, and updated through common key/value
+    // pair conflicts, so the expected key/value pairs should be
+    // exaclty the those added plus those common key/value pairs
+    // changed.
+
+    TestDictionaryKeysAndValues(lBaseDictionaryRef,
+                                &kExpectedKeys[0],
+                                &kExpectedValues[0],
+                                kExpectedKeyCount);
+
+    // Clear the base dictionary and reestablish the baseline pre-test
+    // key/value pairs.
+
+    CFDictionaryRemoveAllValues(lBaseDictionaryRef);
+
+    TestDictionaryPopulateWithKeysAndValues(&kBaseKeys[0],
+                                            &kBaseValues[0],
+                                            kBaseKeyCount,
+                                            lBaseDictionaryRef);
+
+    lStatus = CFUDictionaryMerge(lBaseDictionaryRef,
+                                 lAddedDictionaryRef,
+                                 lCommonDictionaryRef,
+                                 lRemovedKeysArrayRef);
+    CPPUNIT_ASSERT(lStatus == true);
+
+    // Validate the base dictionary keys and values are as expected
+    // after the merge.
+    //
+    // Keys were added, removed, and updated through common key/value
+    // pair conflicts, so the expected key/value pairs should be
+    // exaclty the those added plus those common key/value pairs
+    // changed.
+
+    TestDictionaryKeysAndValues(lBaseDictionaryRef,
+                                &kExpectedKeys[0],
+                                &kExpectedValues[0],
+                                kExpectedKeyCount);
+
+    // Test Teardown
+
+    TestTeardown(lBaseDictionaryRef,
+                 lAddedDictionaryRef,
+                 lCommonDictionaryRef,
+                 lRemovedDictionaryRef,
+                 lRemovedKeysArrayRef);
+}
+
+void
+TestCFUDictionaryMergeWithDifferences :: TestArrayCreateWithValues(const void **inFirstValue,
+                                                                   const size_t &inCount,
+                                                                   CFMutableArrayRef &outArray)
+{
+    CPPUNIT_ASSERT(outArray == nullptr);
+
+    outArray = CFArrayCreateMutable(kCFAllocatorDefault,
+                                    0,
+                                    &kCFTypeArrayCallBacks);
+    CPPUNIT_ASSERT(outArray != nullptr);
+
+    for (size_t i = 0; i < inCount; i++)
+    {
+        CFArrayInsertValueAtIndex(outArray, i, inFirstValue[i]);
+    }
+}
+
+void
+TestCFUDictionaryMergeWithDifferences :: TestDictionaryPopulateWithKeysAndValues(const void **inFirstKey,
+                                                                                 const void **inFirstValue,
+                                                                                 const size_t &inCount,
+                                                                                 CFMutableDictionaryRef &inOutDictionary)
+{
+    CPPUNIT_ASSERT(inOutDictionary != nullptr);
+
+    for (size_t i = 0; i < inCount; i++)
+    {
+        CFDictionaryAddValue(inOutDictionary, inFirstKey[i], inFirstValue[i]);
+    }
+}
+
+void
+TestCFUDictionaryMergeWithDifferences :: TestDictionaryCreateWithKeysAndValues(const void **inFirstKey,
+                                                                               const void **inFirstValue,
+                                                                               const size_t &inCount,
+                                                                               CFMutableDictionaryRef &outDictionary)
+{
+    CPPUNIT_ASSERT(outDictionary == nullptr);
+
+    outDictionary = CFDictionaryCreateMutable(kCFAllocatorDefault,
+                                              0,
+                                              &kCFTypeDictionaryKeyCallBacks,
+                                              &kCFTypeDictionaryValueCallBacks);
+    CPPUNIT_ASSERT(outDictionary != nullptr);
+
+    TestDictionaryPopulateWithKeysAndValues(inFirstKey,
+                                            inFirstValue,
+                                            inCount,
+                                            outDictionary);
+}
+
+void
+TestCFUDictionaryMergeWithDifferences :: TestSetup(const void **inFirstBaseDictionaryKey,
+                                                   const void **inFirstBaseDictionaryValue,
+                                                   const size_t &inBaseDictionaryCount,
+                                                   CFMutableDictionaryRef &outBaseDictionaryRef,
+                                                   const void **inFirstAddedDictionaryKey,
+                                                   const void **inFirstAddedDictionaryValue,
+                                                   const size_t &inAddedDictionaryCount,
+                                                   CFMutableDictionaryRef &outAddedDictionaryRef,
+                                                   const void **inFirstCommonDictionaryKey,
+                                                   const void **inFirstCommonDictionaryValue,
+                                                   const size_t &inCommonDictionaryCount,
+                                                   CFMutableDictionaryRef &outCommonDictionaryRef,
+                                                   const void **inFirstRemovedDictionaryKey,
+                                                   const void **inFirstRemovedDictionaryValue,
+                                                   const size_t &inRemovedDictionaryCount,
+                                                   CFMutableDictionaryRef &outRemovedDictionaryRef,
+                                                   const void **inFirstRemovedKeysArrayKey,
+                                                   const size_t &inRemovedKeysArrayCount,
+                                                   CFMutableArrayRef &outRemovedKeysArrayRef)
+{
+    TestDictionaryCreateWithKeysAndValues(inFirstBaseDictionaryKey,
+                                          inFirstBaseDictionaryValue,
+                                          inBaseDictionaryCount,
+                                          outBaseDictionaryRef);
+
+    TestDictionaryCreateWithKeysAndValues(inFirstAddedDictionaryKey,
+                                          inFirstAddedDictionaryValue,
+                                          inAddedDictionaryCount,
+                                          outAddedDictionaryRef);
+
+    TestDictionaryCreateWithKeysAndValues(inFirstCommonDictionaryKey,
+                                          inFirstCommonDictionaryValue,
+                                          inCommonDictionaryCount,
+                                          outCommonDictionaryRef);
+
+    TestDictionaryCreateWithKeysAndValues(inFirstRemovedDictionaryKey,
+                                          inFirstRemovedDictionaryValue,
+                                          inRemovedDictionaryCount,
+                                          outRemovedDictionaryRef);
+
+    TestArrayCreateWithValues(inFirstRemovedKeysArrayKey,
+                              inRemovedKeysArrayCount,
+                              outRemovedKeysArrayRef);
+}
+
+void
+TestCFUDictionaryMergeWithDifferences :: TestDictionaryKeysAndValues(CFDictionaryRef inDictionary,
+                                                           const void **inExpectedFirstKey,
+                                                           const void **inExpectedFirstValue,
+                                                           const size_t &inExpectedCount)
+{
+    CFIndex lDictionaryCount;
+
+    CPPUNIT_ASSERT(inDictionary != nullptr);
+
+    lDictionaryCount = CFDictionaryGetCount(inDictionary);
+    CPPUNIT_ASSERT(static_cast<size_t>(lDictionaryCount) == inExpectedCount);
+
+    for (size_t i = 0; i < inExpectedCount; i++)
+    {
+        CFStringRef            lStringValue;
+        CFComparisonResult     lComparisonResult;
+
+        lStringValue = reinterpret_cast<CFStringRef>(
+            CFDictionaryGetValue(inDictionary, inExpectedFirstKey[i]));
+        CPPUNIT_ASSERT(lStringValue != NULL);
+
+        lComparisonResult =
+            CFStringCompare(lStringValue,
+                            reinterpret_cast<CFStringRef>(inExpectedFirstValue[i]),
+                            0);
+        CPPUNIT_ASSERT(lComparisonResult == kCFCompareEqualTo);
+    }
+}
+
+void
+TestCFUDictionaryMergeWithDifferences :: TestTeardown(CFMutableDictionaryRef &inBaseDictionaryRef,
+                                                      CFMutableDictionaryRef &inAddedDictionaryRef,
+                                                      CFMutableDictionaryRef &inCommonDictionaryRef,
+                                                      CFMutableDictionaryRef &inRemovedDictionaryRef,
+                                                      CFMutableArrayRef &inRemovedKeysArrayRef)
+{
+    CPPUNIT_ASSERT(inBaseDictionaryRef    != nullptr);
+    CPPUNIT_ASSERT(inAddedDictionaryRef   != nullptr);
+    CPPUNIT_ASSERT(inCommonDictionaryRef  != nullptr);
+    CPPUNIT_ASSERT(inRemovedDictionaryRef != nullptr);
+    CPPUNIT_ASSERT(inRemovedKeysArrayRef  != nullptr);
+
+    CFRelease(inBaseDictionaryRef);
+    CFRelease(inAddedDictionaryRef);
+    CFRelease(inCommonDictionaryRef);
+    CFRelease(inRemovedDictionaryRef);
+    CFRelease(inRemovedKeysArrayRef);
+}


### PR DESCRIPTION
This adds C/C++ bindings for `CFUDictionaryMerge{,WithDifferences,WithDifferencesAndRemovedKeys}` which attempts to merge a CoreFoundation dictionary from one or more "difference" dictionaries, typically created with `CFUDictionaryDifference`.