### PR TITLE
Correct 'NL_WITH_REQUIRED_EXTERNAL_PACKAGE' 'DEFAULT-PACKAGE-LIBS' Arguments

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -383,7 +383,7 @@ if test "${nl_cv_build_tests}" = "yes"; then
     NL_WITH_REQUIRED_EXTERNAL_PACKAGE([CppUnit],
     [CPPUNIT],
     [cppunit],
-    [cppunit],
+    [-lcppunit],
     [
         # Check for required Boost (C++) headers.
 

--- a/configure.ac
+++ b/configure.ac
@@ -411,7 +411,7 @@ if test "${with_corefoundation_source}" == "cflite"; then
     NL_WITH_REQUIRED_EXTERNAL_PACKAGE([CoreFoundation],
     [CF],
     [CoreFoundation],
-    [CoreFoundation],
+    [-lCoreFoundation],
     [
         # Check for required CoreFoundation (via [Open]CFLite) headers.
 


### PR DESCRIPTION
The `DEFAULT-PACKAGE-LIBS` argument for the `NL_WITH_REQUIRED_EXTERNAL_PACKAGE` _m4_ _autoconf_ macro was incorrect for both _CoreFoundation_ and _cppunit_.

The `DEFAULT-PACKAGE-LIBS` argument for `NL_WITH_REQUIRED_EXTERNAL_PACKAGE` needs an as-passed-to-the-compiler library argument. Consequently, `CoreFoundation` and `pcpunit` as the argument parameters were insufficient and needed to be `-lCoreFoundation` and `-lcppunit`, respectively.
