### PR TITLE
Address GitHub Workflow Action for macOS Apple Silicon and Homebrew

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -184,7 +184,7 @@ jobs:
       run: |
         eval "$(brew shellenv)"
         export PATH="$(brew --prefix m4)/bin:${PATH}"
-        ./bootstrap-configure -C --enable-coverage --with-boost=/usr/local
+        ./bootstrap-configure -C --enable-coverage --with-boost="$(brew --prefix boost)" --with-cppunit="$(brew --prefix cppunit)"
 
     - name: Coding Style
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -182,6 +182,7 @@ jobs:
 
     - name: Bootstrap and Configure
       run: |
+        eval "$(brew shellenv)"
         export PATH="$(brew --prefix m4)/bin:${PATH}"
         ./bootstrap-configure -C --enable-coverage --with-boost=/usr/local
 


### PR DESCRIPTION
On macOS, Intel versus Apple silicon has created variability as far as Homebrew is concerned. On the former, Homebrew formulae are installed in _/usr/local_ and on the latter, in _/opt/homebrew_. There's no way to know a priori on which architecture the job will run. Consequently, we need to handle both.

Pick-up _boost_ and _cppunit_ from wherever Homebrew installed them by using the `brew --prefix <package>` command with the `--with-<package>` `configure` options.