### PR TITLE
Add autoconf Program Check for 'egrep'

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -193,6 +193,7 @@ AC_CHECK_TOOL(STRIP, strip)
 
 # Check for other host tools.
 
+AC_PROG_EGREP
 AC_PROG_INSTALL
 AC_PROG_LN_S
 


### PR DESCRIPTION
If the package is configured with documentation, _Doxygen_ uses `egrep`. Consequently, added the `AC_PROG_EGREP` macro to _configure.ac_, addressing issue #25.