### PR TITLE
Address Top-of-tree '-Wsign-conversion' Errors / Warnings in Unit Tests

### DIFF
--- a/tests/TestCFUDictionaryDifference.cpp
+++ b/tests/TestCFUDictionaryDifference.cpp
@@ -1400,7 +1400,7 @@ TestCFUDictionaryDifference :: TestDictionaryCreateWithKeysAndValues(const void 
     outDictionary = CFDictionaryCreate(kCFAllocatorDefault,
                                        inFirstKey,
                                        inFirstValue,
-                                       inCount,
+                                       static_cast<CFIndex>(inCount),
                                        &kCFTypeDictionaryKeyCallBacks,
                                        &kCFTypeDictionaryValueCallBacks);
     CPPUNIT_ASSERT(outDictionary != nullptr);

--- a/tests/TestCFUDictionaryMergeWithDifferences.cpp
+++ b/tests/TestCFUDictionaryMergeWithDifferences.cpp
@@ -1544,7 +1544,7 @@ TestCFUDictionaryMergeWithDifferences :: TestArrayCreateWithValues(const void **
 
     for (size_t i = 0; i < inCount; i++)
     {
-        CFArrayInsertValueAtIndex(outArray, i, inFirstValue[i]);
+        CFArrayInsertValueAtIndex(outArray, static_cast<CFIndex>(i), inFirstValue[i]);
     }
 }
 


### PR DESCRIPTION
This addresses #27 by applying `static_cast` casts between `CFIndex` and `size_t` conversions.